### PR TITLE
ci: configure `commitlint` to check commits from forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,7 @@ jobs:
   commits:
     name: Check commits
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,4 +46,28 @@ jobs:
           npx commitlint \
             --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} \
             --to ${{ github.event.pull_request.head.sha }} \
+            --verbose
+  commits-fork:
+    name: Check commits from forks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+      - name: Install dependencies
+        run: npm install -g @commitlint/cli @commitlint/config-conventional
+      - name: Configure
+        run: |
+          echo 'module.exports = {"extends": ["@commitlint/config-conventional"]}' > commitlint.config.js
+      - name: Validate
+        run: |
+          git fetch origin "+refs/pull/${{ github.event.pull_request.number }}/head:refs/pull/${{ github.event.pull_request.number }}/head"
+          git checkout "refs/pull/${{ github.event.pull_request.number }}/head"
+          npx commitlint \
+            --from HEAD~${{ github.event.pull_request.commits }} \
+            --to HEAD \
             --verbose

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const withdrawal = await wallet.withdraw({
 
 ## 🤖 Running tests
 
-In order to run test you need run [local-setup](https://github.com/matter-labs/local-setup) on your machine.
+In order to run test you need to run [local-setup](https://github.com/matter-labs/local-setup) on your machine.
 For running tests, use:
 
 ```shell


### PR DESCRIPTION
# What :computer: 
* Add conditional step in validation pipeline that checks commit messages from fork repositories.

# Why :hand:
* Contributors needs to follow conventional commits.
