### PR TITLE
fix : "eip-1559 transaction do not support gasPrice"

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1075,7 +1075,9 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
     populated.value ??= 0;
     populated.data ??= '0x';
     populated.customData = this._fillCustomData(tx.customData ?? {});
-    populated.gasPrice = await this.provider.getGasPrice();
+    if (!populated.maxFeePerGas && !populated.maxPriorityFeePerGas) {
+      populated.gasPrice = await this.provider.getGasPrice();
+    }
     return populated;
   }
 


### PR DESCRIPTION
# What :computer: 
* avoid adding gasPrice in eip-1559 transaction request

# Why :hand:
* I meet the error "eip-1559 transaction do not support gasPrice", when integrating mute paymaster with zksync-ethers@5.3.0. After debug, I find the populateTransaction method always add gasPrice for transactionRequest even it is eip-1559 transaction, which result into error report in ethers@5 side.

# Evidence :camera:
![image](https://github.com/zksync-sdk/zksync-ethers/assets/111430753/d319bd4f-9d06-47e1-9c26-44d7d356326b)

# Notes :memo:
* Co-author : samzkback <geeksam820@gmail.com>
* Co-author : Connor Leigh-Smith <connorbob21@gmail.com>
