### PR TITLE
fix: wallet.sendTransaction with customData incorrectly throwing TypeError

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1075,7 +1075,9 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
     populated.value ??= 0;
     populated.data ??= '0x';
     populated.customData = this._fillCustomData(tx.customData ?? {});
-    populated.gasPrice = await this.provider.getGasPrice();
+    if (!populated.maxFeePerGas && !populated.maxPriorityFeePerGas) {
+      populated.gasPrice = await this.provider.getGasPrice();
+    }
     return populated;
   }
 


### PR DESCRIPTION
# What :computer: 

tl;dr this fixes a bug causing `TypeError: eip-1559 transaction do not support gasPrice` to be thrown unexpectedly. Steps to reproduce bug:

- Craft a transaction manually with `maxFeePerGas` or `maxPriorityFeePerGas` set, as well as the `customData` field (in my case, for trying Paymaster).
- Sign and broadcast this transaction with `wallet.sendTransaction(tx)`


# Why :hand:

The issue is, `sendTransaction` calls `this.populateTransaction` which currently succeeds and adds `gasPrice` to the transaction. Then, `sendTransaction` calls `this.signTransaction` which again calls `this.populateTransaction`. This second time, `super.populateTransaction` is called again but because `gasPrice` has been added in addition to the EIP fields, it throws `TypeError: eip-1559 transaction do not support gasPrice`.

In my use case, I was able to work around this by calling `wallet.signTransaction(tx)` followed by `provider.broadcastTransaction(signedTx)`. This works fine because the wallet's `populateTransaction` is only called once and the `gasPrice` field is added after this is a problem. Most likely this is how many people are submitting transactions, so they won't hit this problem, but it's a nasty one when it does happen.

My PR here seems the least intrusive way to fix this. It may be ideal to prefer setting `maxFeePerGas` over `gasPrice`, but I did not want to risk changing existing behaviour. Instead, it will simply omit setting `gasPrice` if the user has already set one of the EIP1559 fields.

# Evidence :camera:

Example errored transaction when using `sendTransaction` under these circumstances:

```
TypeError: eip-1559 transaction do not support gasPrice (argument="tx", value={ "chainId": 324, "customData": { "factoryDeps": [  ], "gasPerPubdata": 50000, "paymasterParams": { "paymaster": "___", "paymasterInput": "0x8c5a344500000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000" } }, "data": "0x5b7d7482000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000004033313339663732316238626365666564313739363763363132653835306266623964306561376139666564653434333732636533656636643930663937323962000000000000000000000000000000000000000000000000000000000000004033313339663732316238626365666564313739363763363132653835306266623964306561376139666564653434333732636533656636643930663937323962", "from": "___", "gasLimit": 530508, "gasPrice": 100000000, "maxFeePerGas": 1200000000, "maxPriorityFeePerGas": 1000000000, "nonce": 4, "to": "___", "type": 113, "value": 0 }, code=INVALID_ARGUMENT, version=6.11.1)
```

When calling `signTransaction` followed by `broadcastTransaction`, the above transaction goes through fine and the transaction response does not include a value for `gasPrice`.

# Notes

Admittedly I was unable to run the tests. I did add a new test for this, but since I could not run the integration tests locally I could not verify it's passing. The test is here if you're interested: https://github.com/SharkofMirkwood/zksync-ethers/compare/patch-4...SharkofMirkwood:zksync-ethers:patch-4-test?expand=1