### PR TITLE
Make `populateTransaction` compatible with `ethers` validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run tests
 on:
   workflow_dispatch:
   pull_request:
-    branch: ethers-v5
+    branches: [ethers-v5]
     types: [ opened, reopened, synchronize ]
 
 permissions:
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Install dependencies
-        run: npm install -g @commitlint/cli @commitlint/config-conventional
+        run: npm install -g @commitlint/cli@18.6.1 @commitlint/config-conventional@18.6.2
       - name: Configure
         run: |
           echo 'module.exports = {"extends": ["@commitlint/config-conventional"]}' > commitlint.config.js
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Install dependencies
-        run: npm install -g @commitlint/cli @commitlint/config-conventional
+        run: npm install -g @commitlint/cli@18.6.1 @commitlint/config-conventional@18.6.2
       - name: Configure
         run: |
           echo 'module.exports = {"extends": ["@commitlint/config-conventional"]}' > commitlint.config.js

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,7 @@
 name: Validate
 on:
   pull_request:
-    branch: ethers-v5
+    branches: [ethers-v5]
     types: [ opened, reopened, synchronize ]
 
 permissions:
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies
@@ -30,9 +30,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies
@@ -53,9 +53,9 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -34,9 +34,9 @@ import {
     undoL1ToL2Alias,
     NONCE_HOLDER_ADDRESS,
 } from "./utils";
-import {Il2Bridge} from "../typechain/Il2Bridge";
-import {IZkSync} from "../typechain/IZkSync";
-import {Il1Bridge} from "../typechain/Il1Bridge";
+import { Il2Bridge } from "../typechain/Il2Bridge";
+import { IZkSync } from "../typechain/IZkSync";
+import { Il1Bridge } from "../typechain/Il1Bridge";
 
 type Constructor<T = {}> = new (...args: any[]) => T;
 
@@ -64,7 +64,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
             return IZkSyncFactory.connect(address, this._signerL1());
         }
 
-        async getL1BridgeContracts(): Promise<{erc20: Il1Bridge; weth: Il1Bridge}> {
+        async getL1BridgeContracts(): Promise<{ erc20: Il1Bridge; weth: Il1Bridge }> {
             const addresses = await this._providerL2().getDefaultBridgeAddresses();
             return {
                 erc20: IL1BridgeFactory.connect(addresses.erc20L1!, this._signerL1()),
@@ -528,7 +528,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
             const sender = ethers.utils.hexDataSlice(log.topics[1], 12);
             const proof = await this._providerL2().getLogProof(withdrawalHash, l2ToL1LogIndex);
             if (!proof) {
-                throw new Error('Log proof not found!');
+                throw new Error("Log proof not found!");
             }
             const message = ethers.utils.defaultAbiCoder.decode(["bytes"], log.data)[0];
             return {
@@ -599,7 +599,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
             // which is returned as `proof.id`.
             const proof = await this._providerL2().getLogProof(withdrawalHash, l2ToL1LogIndex);
             if (!proof) {
-                throw new Error('Log proof not found!');
+                throw new Error("Log proof not found!");
             }
 
             if (isETH(sender)) {
@@ -615,7 +615,10 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
             return await l1Bridge.isWithdrawalFinalized(log.l1BatchNumber, proof.id);
         }
 
-        async claimFailedDeposit(depositHash: BytesLike, overrides?: ethers.Overrides): Promise<ethers.ContractTransaction> {
+        async claimFailedDeposit(
+            depositHash: BytesLike,
+            overrides?: ethers.Overrides,
+        ): Promise<ethers.ContractTransaction> {
             const receipt = await this._providerL2().getTransactionReceipt(
                 ethers.utils.hexlify(depositHash),
             );
@@ -641,7 +644,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
 
             const proof = await this._providerL2().getLogProof(depositHash, successL2ToL1LogIndex);
             if (!proof) {
-                throw new Error('Log proof not found!');
+                throw new Error("Log proof not found!");
             }
 
             return await l1Bridge.claimFailedDeposit(
@@ -778,7 +781,7 @@ export function AdapterL2<TBase extends Constructor<TxSender>>(Base: TBase) {
             ).getDeploymentNonce(await this.getAddress());
         }
 
-        async getL2BridgeContracts(): Promise<{erc20: Il2Bridge; weth: Il2Bridge}> {
+        async getL2BridgeContracts(): Promise<{ erc20: Il2Bridge; weth: Il2Bridge }> {
             const addresses = await this._providerL2().getDefaultBridgeAddresses();
             return {
                 erc20: IL2BridgeFactory.connect(addresses.erc20L2!, this._signerL2()),

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -15,7 +15,7 @@ import { hexlify, isBytes, isHexString } from "@ethersproject/bytes";
 export { Contract } from "ethers";
 
 export class ContractFactory extends ethers.ContractFactory {
-    override readonly signer: Wallet | Signer;
+    override readonly signer!: Wallet | Signer;
     readonly deploymentType: DeploymentType;
 
     constructor(
@@ -92,7 +92,7 @@ export class ContractFactory extends ethers.ContractFactory {
         const bytecodeHash = hashBytecode(this.bytecode);
         const constructorCalldata = utils.arrayify(this.interface.encodeDeploy(constructorArgs));
         const deployCalldata = this.encodeCalldata(
-            overrides.customData.salt,
+            overrides.customData!.salt,
             bytecodeHash,
             constructorCalldata,
         );
@@ -107,7 +107,7 @@ export class ContractFactory extends ethers.ContractFactory {
         };
 
         tx.customData ??= {};
-        tx.customData.factoryDeps ??= overrides.customData.factoryDeps || [];
+        tx.customData.factoryDeps ??= overrides.customData!.factoryDeps;
         tx.customData.gasPerPubdata ??= DEFAULT_GAS_PER_PUBDATA_LIMIT;
 
         // The number of factory deps is relatively low, so it is efficient enough.
@@ -176,13 +176,13 @@ export class ContractFactory extends ethers.ContractFactory {
 }
 
 function normalizeBytecode(bytecode: BytesLike | { object: string }) {
-    let bytecodeHex: string = null;
+    let bytecodeHex: string;
 
     if (typeof bytecode === "string") {
         bytecodeHex = bytecode;
     } else if (isBytes(bytecode)) {
         bytecodeHex = hexlify(bytecode);
-    } else if (bytecode && typeof bytecode.object === "string") {
+    } else if (bytecode) {
         // Allow the bytecode object from the Solidity compiler
         bytecodeHex = (<any>bytecode).object;
     } else {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -375,7 +375,11 @@ export class Provider extends ethers.providers.JsonRpcProvider {
         return defaultFormatter;
     }
 
-    override async getBalance(address: Address, blockTag?: BlockTag, tokenAddress?: Address): Promise<BigNumber> {
+    override async getBalance(
+        address: Address,
+        blockTag?: BlockTag,
+        tokenAddress?: Address,
+    ): Promise<BigNumber> {
         const tag = this.formatter.blockTag(blockTag);
         if (tokenAddress == null || isETH(tokenAddress)) {
             // requesting ETH balance
@@ -469,9 +473,9 @@ export class Provider extends ethers.providers.JsonRpcProvider {
 
     override async estimateGas(transaction: utils.Deferrable<TransactionRequest>): Promise<BigNumber> {
         await this.getNetwork();
-        const params = await utils.resolveProperties({
+        const params = (await utils.resolveProperties({
             transaction: this._getTransactionRequest(transaction),
-        }) as {transaction: TransactionRequest};
+        })) as { transaction: TransactionRequest };
         if (transaction.customData != null) {
             params.transaction.customData = transaction.customData;
         }
@@ -493,7 +497,9 @@ export class Provider extends ethers.providers.JsonRpcProvider {
             params.transaction.customData = transaction.customData;
         }
         const result = await this.send("zks_estimateGasL1ToL2", [
-            Provider.hexlifyTransaction(params.transaction as ethers.providers.TransactionRequest, { from: true }),
+            Provider.hexlifyTransaction(params.transaction as ethers.providers.TransactionRequest, {
+                from: true,
+            }),
         ]);
         try {
             return BigNumber.from(result);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -93,8 +93,8 @@ export class EIP712Signer {
 // const tx = await signer.sendTransaction({ ... });
 /* c8 ignore start */
 export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
-    public override provider: Provider;
-    public eip712: EIP712Signer;
+    public override provider!: Provider;
+    public eip712!: EIP712Signer;
 
     override _signerL2() {
         return this;
@@ -133,7 +133,7 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
             transaction.value ??= 0;
             transaction.data ??= "0x";
             transaction.nonce ??= await this.getNonce();
-            transaction.customData = this._fillCustomData(transaction.customData);
+            transaction.customData = this._fillCustomData(transaction.customData ?? {});
             transaction.gasPrice ??= await this.provider.getGasPrice();
             transaction.gasLimit ??= await this.provider.estimateGas(transaction);
             transaction.chainId ??= (await this.provider.getNetwork()).chainId;
@@ -153,7 +153,7 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
 // const signer = zkweb3.L1Signer.from(provider.getSigner(), zksyncProvider);
 // const tx = await signer.deposit({ ... });
 export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
-    public providerL2: Provider;
+    public providerL2!: Provider;
     override _providerL2() {
         return this.providerL2;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,14 +52,14 @@ export const L1_FEE_ESTIMATION_COEF_NUMERATOR = BigNumber.from(12);
 export const L1_FEE_ESTIMATION_COEF_DENOMINATOR = BigNumber.from(10);
 
 // This gas limit will be used for displaying the error messages when the users do not have enough fee.
-export const L1_RECOMMENDED_MIN_ERC20_DEPOSIT_GAS_LIMIT = 400000;
-export const L1_RECOMMENDED_MIN_ETH_DEPOSIT_GAS_LIMIT = 200000;
+export const L1_RECOMMENDED_MIN_ERC20_DEPOSIT_GAS_LIMIT = 400_000;
+export const L1_RECOMMENDED_MIN_ETH_DEPOSIT_GAS_LIMIT = 200_000;
 
 // The large L2 gas per pubdata to sign. This gas is enough to ensure that
 // any reasonable limit will be accepted. Note, that the operator is NOT required to
 // use the honest value of gas per pubdata, and it can use any value up to the one signed by the user.
 // In the future releases, we will provide a way to estimate the current gasPerPubdata.
-export const DEFAULT_GAS_PER_PUBDATA_LIMIT = 50000;
+export const DEFAULT_GAS_PER_PUBDATA_LIMIT = 50_000;
 
 // It is possible to provide practically any gasPerPubdataByte for L1->L2 transactions, since
 // the cost per gas will be adjusted respectively. We will use 800 as a relatively optimal value for now.
@@ -271,7 +271,7 @@ export function hashBytecode(bytecode: ethers.BytesLike): Uint8Array {
 }
 
 export function parseTransaction(payload: ethers.BytesLike): ethers.Transaction {
-    function handleAddress(value: string): string {
+    function handleAddress(value: string): string | null {
         if (value === "0x") {
             return null;
         }
@@ -381,7 +381,7 @@ export function getL2HashFromPriorityOp(
     txReceipt: ethers.providers.TransactionReceipt,
     zkSyncAddress: Address,
 ): string {
-    let txHash: string = null;
+    let txHash: string | null = null;
     for (const log of txReceipt.logs) {
         if (log.address.toLowerCase() != zkSyncAddress.toLowerCase()) {
             continue;
@@ -559,7 +559,7 @@ export async function estimateDefaultBridgeDepositL2Gas(
     } else {
         let value, l1BridgeAddress, l2BridgeAddress, bridgeData;
         const bridgeAddresses = await providerL2.getDefaultBridgeAddresses();
-        const l1WethBridge = IL1BridgeFactory.connect(bridgeAddresses.wethL1, providerL1);
+        const l1WethBridge = IL1BridgeFactory.connect(bridgeAddresses.wethL1!, providerL1);
         let l2WethToken = ethers.constants.AddressZero;
         try {
             l2WethToken = await l1WethBridge.l2TokenAddress(token);
@@ -579,8 +579,8 @@ export async function estimateDefaultBridgeDepositL2Gas(
 
         return await estimateCustomBridgeDepositL2Gas(
             providerL2,
-            l1BridgeAddress,
-            l2BridgeAddress,
+            l1BridgeAddress!,
+            l2BridgeAddress!,
             token,
             amount,
             to,
@@ -608,7 +608,7 @@ export async function estimateCustomBridgeDepositL2Gas(
     gasPerPubdataByte?: BigNumberish,
     l2Value?: BigNumberish,
 ): Promise<BigNumber> {
-    const calldata = await getERC20BridgeCalldata(token, from, to, amount, bridgeData);
+    const calldata = await getERC20BridgeCalldata(token, from!, to, amount, bridgeData);
     return await providerL2.estimateL1ToL2Execute({
         caller: applyL1ToL2Alias(l1BridgeAddress),
         contractAddress: l2BridgeAddress,

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,7 +1,7 @@
 import { EIP712Signer } from "./signer";
 import { Provider } from "./provider";
 import { serialize, EIP712_TX_TYPE } from "./utils";
-import {Bytes, ethers, utils} from "ethers";
+import { Bytes, ethers, utils } from "ethers";
 import { BlockTag, TransactionResponse, TransactionRequest } from "./types";
 import { ProgressCallback } from "@ethersproject/json-wallets";
 import { AdapterL1, AdapterL2 } from "./adapters";
@@ -56,13 +56,13 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
         json: string,
         password?: string | ethers.Bytes,
         callback?: ProgressCallback,
-    ):Promise<Wallet> {
-        const wallet = await super.fromEncryptedJson(json, password as (string | Bytes), callback);
+    ): Promise<Wallet> {
+        const wallet = await super.fromEncryptedJson(json, password as string | Bytes, callback);
         return new Wallet(wallet._signingKey());
     }
 
     static override fromEncryptedJsonSync(json: string, password?: string | ethers.Bytes): Wallet {
-        const wallet = super.fromEncryptedJsonSync(json, password as (string | Bytes));
+        const wallet = super.fromEncryptedJsonSync(json, password as string | Bytes);
         return new Wallet(wallet._signingKey());
     }
 
@@ -85,7 +85,10 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
     }
 
     override async populateTransaction(transaction: TransactionRequest): Promise<TransactionRequest> {
-        if ((transaction.type == null || transaction.type !== EIP712_TX_TYPE) && transaction.customData == null) {
+        if (
+            (transaction.type == null || transaction.type !== EIP712_TX_TYPE) &&
+            transaction.customData == null
+        ) {
             return await super.populateTransaction(transaction);
         }
         transaction.type = EIP712_TX_TYPE;

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -59,7 +59,7 @@ describe("ContractFactory", () => {
                 // @ts-ignore
                 new ContractFactory(abi, bytecode, wallet, "null");
             } catch (e) {
-                expect(e.message).to.be.equal("Unsupported deployment type null");
+                expect((e as Error).message).to.be.equal("Unsupported deployment type null");
             }
         });
     });
@@ -192,7 +192,7 @@ describe("ContractFactory", () => {
             try {
                 factory.getDeployTransaction("Ducat", "Ducat", 18);
             } catch (e) {
-                expect(e.message).to.be.equal("Salt is required for CREATE2 deployment!");
+                expect((e as Error).message).to.be.equal("Salt is required for CREATE2 deployment!");
             }
         }).timeout(10_000);
 
@@ -206,7 +206,7 @@ describe("ContractFactory", () => {
                     customData: { salt: "0000" },
                 });
             } catch (e) {
-                expect(e.message).to.be.equal("Invalid salt provided!");
+                expect((e as Error).message).to.be.equal("Invalid salt provided!");
             }
         }).timeout(10_000);
 
@@ -220,7 +220,7 @@ describe("ContractFactory", () => {
                     customData: { salt: "0x000" },
                 });
             } catch (e) {
-                expect(e.message).to.be.equal("Invalid salt provided!");
+                expect((e as Error).message).to.be.equal("Invalid salt provided!");
             }
         }).timeout(10_000);
 
@@ -237,7 +237,7 @@ describe("ContractFactory", () => {
                     },
                 });
             } catch (e) {
-                expect(e.message).to.be.equal(
+                expect((e as Error).message).to.be.equal(
                     "Invalid 'factoryDeps' format! It should be an array of bytecodes.",
                 );
             }
@@ -250,7 +250,7 @@ describe("ContractFactory", () => {
                     },
                 });
             } catch (e) {
-                expect(e.message).to.be.equal(
+                expect((e as Error).message).to.be.equal(
                     "Invalid 'factoryDeps' format! It should be an array of bytecodes.",
                 );
             }

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -180,7 +180,7 @@ describe("ContractFactory", () => {
             const bytecode: string = require(tokenPath).bytecode;
             const factory = new ContractFactory(abi, bytecode, wallet);
 
-            const result = await factory.getDeployTransaction("Ducat", "Ducat", 18);
+            const result = factory.getDeployTransaction("Ducat", "Ducat", 18);
             expect(result).not.to.be.null;
         }).timeout(10_000);
 
@@ -190,7 +190,7 @@ describe("ContractFactory", () => {
             const factory = new ContractFactory(abi, bytecode, wallet, "create2");
 
             try {
-                await factory.getDeployTransaction("Ducat", "Ducat", 18);
+                factory.getDeployTransaction("Ducat", "Ducat", 18);
             } catch (e) {
                 expect(e.message).to.be.equal("Salt is required for CREATE2 deployment!");
             }
@@ -202,7 +202,7 @@ describe("ContractFactory", () => {
             const factory = new ContractFactory(abi, bytecode, wallet, "create2");
 
             try {
-                await factory.getDeployTransaction("Ducat", "Ducat", 18, {
+                factory.getDeployTransaction("Ducat", "Ducat", 18, {
                     customData: { salt: "0000" },
                 });
             } catch (e) {
@@ -216,7 +216,7 @@ describe("ContractFactory", () => {
             const factory = new ContractFactory(abi, bytecode, wallet, "create2");
 
             try {
-                await factory.getDeployTransaction("Ducat", "Ducat", 18, {
+                factory.getDeployTransaction("Ducat", "Ducat", 18, {
                     customData: { salt: "0x000" },
                 });
             } catch (e) {
@@ -230,7 +230,7 @@ describe("ContractFactory", () => {
             const factory = new ContractFactory(abi, bytecode, wallet, "create2");
 
             try {
-                await factory.getDeployTransaction("Ducat", "Ducat", 18, {
+                factory.getDeployTransaction("Ducat", "Ducat", 18, {
                     customData: {
                         salt: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
                         factoryDeps: "0",
@@ -243,7 +243,7 @@ describe("ContractFactory", () => {
             }
 
             try {
-                await factory.getDeployTransaction("Ducat", "Ducat", 18, {
+                factory.getDeployTransaction("Ducat", "Ducat", 18, {
                     customData: {
                         salt: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
                         factoryDeps: "",

--- a/tests/integration/paymaster.test.ts
+++ b/tests/integration/paymaster.test.ts
@@ -24,7 +24,7 @@ describe("Paymaster", () => {
             const bytecode: string = require(tokenPath).bytecode;
             const factory = new ContractFactory(abi, bytecode, wallet);
             const tokenContract = (await factory.deploy("Ducat", "Ducat", 18)) as Contract;
-            const tokenAddress = await tokenContract.address;
+            const tokenAddress = tokenContract.address;
 
             // mint tokens to wallet, so it could pay fee with tokens
             await tokenContract.mint(await wallet.getAddress(), INIT_MINT_AMOUNT);
@@ -38,7 +38,7 @@ describe("Paymaster", () => {
                 "createAccount",
             );
             const paymasterContract = await accountFactory.deploy(tokenAddress);
-            const paymasterAddress = await paymasterContract.address;
+            const paymasterAddress = paymasterContract.address;
 
             // transfer ETH to paymaster so it could pay fee
             const faucetTx = await wallet.transfer({

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import "../custom-matchers";
 import { Provider, types, utils, Wallet } from "../../src";
 import { BigNumber, ethers } from "ethers";
 
@@ -164,7 +165,7 @@ describe("Provider", () => {
 
     describe("#getProof()", () => {
         it("should return a storage proof", async () => {
-            // fetchin the storage proof for rawHonce storage slot in NonceHolder system contract
+            // fetching the storage proof for rawNonce storage slot in NonceHolder system contract
             // mapping(uint256 => uint256) internal rawNonces;
 
             // Ensure the address is a 256-bit number by padding it
@@ -334,7 +335,7 @@ describe("Provider", () => {
     describe("#getWithdrawTx()", () => {
         it("should return withdraw transaction", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 value: BigNumber.from(7_000_000_000),
                 to: ethers.utils.getAddress("0x000000000000000000000000000000000000800a"),
                 data: "0x51cff8d900000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049",
@@ -350,7 +351,7 @@ describe("Provider", () => {
 
         it("should return an ETH withdraw transaction with paymaster parameters", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 value: BigNumber.from(7_000_000_000),
                 to: ethers.utils.getAddress("0x000000000000000000000000000000000000800a"),
                 data: "0x51cff8d900000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049",
@@ -379,7 +380,7 @@ describe("Provider", () => {
 
         it("should return a DAI withdraw transaction", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: ethers.utils.getAddress(
                     (await provider.getDefaultBridgeAddresses()).erc20L2 as string,
                 ),
@@ -396,7 +397,7 @@ describe("Provider", () => {
 
         it("should return a DAI withdraw transaction with paymaster parameters", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: ethers.utils.getAddress(
                     (await provider.getDefaultBridgeAddresses()).erc20L2 as string,
                 ),
@@ -426,7 +427,7 @@ describe("Provider", () => {
 
         it("should return a withdraw transaction with `tx.from==tx.to` when `tx.to` is not provided", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 value: BigNumber.from(7_000_000_000),
                 to: "0x000000000000000000000000000000000000800A",
                 data: "0x51cff8d900000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049",
@@ -468,7 +469,7 @@ describe("Provider", () => {
     describe("#getTransferTx()", () => {
         it("should return transfer transaction", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: RECEIVER,
                 value: 7_000_000_000,
             };
@@ -484,7 +485,7 @@ describe("Provider", () => {
         it("should return an ETH transfer transaction with paymaster parameters", async () => {
             const tx = {
                 type: utils.EIP712_TX_TYPE,
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: RECEIVER,
                 value: 7_000_000_000,
                 customData: {
@@ -512,7 +513,7 @@ describe("Provider", () => {
 
         it("should return a DAI transfer transaction", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: await provider.l2TokenAddress(DAI_L1),
                 data: "0xa9059cbb000000000000000000000000a61464658afeaf65cccaafd3a512b69a83b776180000000000000000000000000000000000000000000000000000000000000005",
             };
@@ -527,7 +528,7 @@ describe("Provider", () => {
 
         it("should return a DAI transfer transaction with paymaster parameters", async () => {
             const tx = {
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: await provider.l2TokenAddress(DAI_L1),
                 data: "0xa9059cbb000000000000000000000000a61464658afeaf65cccaafd3a512b69a83b776180000000000000000000000000000000000000000000000000000000000000005",
                 customData: {

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -17,7 +17,7 @@ describe("Provider", () => {
     const TOKEN = "0x841c43Fa5d8fFfdB9efE3358906f7578d8700Dd4";
     const PAYMASTER = "0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174";
 
-    let tx;
+    let tx: types.TransactionResponse;
 
     before("setup", async function () {
         this.timeout(25_000);

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -90,7 +90,7 @@ describe("Wallet", () => {
             try {
                 await wallet.approveERC20(utils.ETH_ADDRESS, 5);
             } catch (e) {
-                expect(e.message).to.be.equal(
+                expect((e as Error).message).to.be.equal(
                     "ETH token can't be approved! The address of the token does not exist on L1.",
                 );
             }
@@ -145,7 +145,7 @@ describe("Wallet", () => {
             try {
                 wallet.ethWallet();
             } catch (e) {
-                expect(e.message).to.be.equal("L1 provider missing: use `connectToL1` to specify!");
+                expect((e as Error).message).to.be.equal("L1 provider missing: use `connectToL1` to specify!");
             }
         });
     });
@@ -615,7 +615,7 @@ describe("Wallet", () => {
             try {
                 await wallet.claimFailedDeposit(tx.transactionHash);
             } catch (e) {
-                expect(e.message).to.be.equal("Cannot claim successful deposit!");
+                expect((e as Error).message).to.be.equal("Cannot claim successful deposit!");
             }
         }).timeout(30_000);
     });
@@ -643,7 +643,7 @@ describe("Wallet", () => {
                     to: await wallet.getAddress(),
                 });
             } catch (e) {
-                expect(e.message).to.be.equal("Not enough allowance to cover the deposit!");
+                expect((e as Error).message).to.be.equal("Not enough allowance to cover the deposit!");
             }
         }).timeout(10_000);
 
@@ -678,7 +678,7 @@ describe("Wallet", () => {
                     to: await wallet.getAddress(),
                 });
             } catch (e) {
-                expect(e.message).to.include("Not enough balance for deposit!");
+                expect((e as Error).message).to.include("Not enough balance for deposit!");
             }
         }).timeout(10_000);
     });
@@ -1059,7 +1059,7 @@ describe("Wallet", () => {
                     value: 7_000_000_000,
                 });
             } catch (e) {
-                expect(e.message).to.be.equal("Transaction `from` address mismatch!");
+                expect((e as Error).message).to.be.equal("Transaction `from` address mismatch!");
             }
         }).timeout(25_000);
     });

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1,6 +1,6 @@
 import * as chai from "chai";
 import "../custom-matchers";
-import { Provider, types, utils, Wallet } from "../../src";
+import { Provider, utils, Wallet } from "../../src";
 import { ethers, BigNumber } from "ethers";
 import * as fs from "fs";
 
@@ -180,11 +180,12 @@ describe("Wallet", () => {
             const tx = {
                 to: RECEIVER,
                 value: 7_000_000,
-                type: 0,
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                type: 2,
+                from: ADDRESS,
                 nonce: await wallet.getNonce("pending"),
                 chainId: 270,
-                gasPrice: BigNumber.from(250_000_000),
+                maxFeePerGas: BigNumber.from(2_000_000_000),
+                maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
             };
             const result = await wallet.populateTransaction({
                 to: RECEIVER,
@@ -192,6 +193,209 @@ describe("Wallet", () => {
             });
             expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
         });
+
+        it("should return populated transaction when `maxFeePerGas` and `maxPriorityFeePerGas` and `customData` are provided", async () => {
+            const tx = {
+                to: RECEIVER,
+                value: 7_000_000,
+                type: 113,
+                from: ADDRESS,
+                nonce: await wallet.getNonce("pending"),
+                data: '0x',
+                chainId: 270,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                    factoryDeps: []
+                }
+            };
+            const result = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                    factoryDeps: []
+                }
+            });
+            expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+        });
+
+        it("should return populated transaction when `maxPriorityFeePerGas` and `customData` are provided", async () => {
+            const tx = {
+                to: RECEIVER,
+                value: 7_000_000,
+                type: 113,
+                from: ADDRESS,
+                nonce: await wallet.getNonce("pending"),
+                data: '0x',
+                chainId: 270,
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                    factoryDeps: []
+                }
+            };
+            const result = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT
+                }
+            });
+            expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+        });
+
+        it("should return populated transaction when `maxFeePerGas` and `customData` are provided", async () => {
+            const tx = {
+                to: RECEIVER,
+                value: 7_000_000,
+                type: 113,
+                from: ADDRESS,
+                nonce: await wallet.getNonce("pending"),
+                data: '0x',
+                chainId: 270,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                    factoryDeps: []
+                }
+            };
+            const result = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT
+                }
+            });
+            expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+        });
+
+        it("should return populated EIP1559 transaction when `maxFeePerGas` and `maxPriorityFeePerGas` are provided", async () => {
+            const tx = {
+                to: RECEIVER,
+                value: 7_000_000,
+                type: 2,
+                from: ADDRESS,
+                nonce: await wallet.getNonce("pending"),
+                chainId: 270,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+            };
+            const result = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+            });
+            expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+        });
+
+        it("should return populated EIP1559 transaction with `maxFeePerGas` and `maxPriorityFeePerGas` same as provided `gasPrice`", async () => {
+            const tx = {
+                to: RECEIVER,
+                value: 7_000_000,
+                type: 2,
+                from: ADDRESS,
+                nonce: await wallet.getNonce("pending"),
+                chainId: 270,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(3_500_000_000),
+            };
+            const result = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                gasPrice: BigNumber.from(3_500_000_000),
+            });
+            expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+        });
+
+        it("should return populated legacy transaction when `type = 0`", async () => {
+          const tx = {
+              to: RECEIVER,
+              value: 7_000_000,
+              type: 0,
+              from: ADDRESS,
+              nonce: await wallet.getNonce("pending"),
+              chainId: 270,
+              gasPrice: BigNumber.from(250_000_000),
+          };
+          const result = await wallet.populateTransaction({
+              type: 0,
+              to: RECEIVER,
+              value: 7_000_000,
+          });
+          expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+      });
+    });
+
+    describe("#sendTransaction()", () => {
+        it("should send already populated transaction with provided `maxFeePerGas` and `maxPriorityFeePerGas` and `customData` fields", async () => {
+            const populatedTx = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+                customData: {
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT
+                }
+            });
+            const tx = await wallet.sendTransaction(populatedTx);
+            const result = await tx.wait();
+            expect(result).not.to.be.null;
+        }).timeout(10_000);
+
+        it("should send EIP1559 transaction when `maxFeePerGas` and `maxPriorityFeePerGas` are provided", async () => {
+            const tx = await wallet.sendTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+            });
+            const result = await tx.wait();
+            expect(result).not.to.be.null;
+            expect(result.type).to.be.equal(2);
+        }).timeout(10_000);
+
+        it("should return already populated EIP1559 transaction with `maxFeePerGas` and `maxPriorityFeePerGas`", async () => {
+            const populatedTx = await wallet.populateTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                maxFeePerGas: BigNumber.from(3_500_000_000),
+                maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+            });
+
+            const tx = await wallet.sendTransaction(populatedTx);
+            const result = await tx.wait();
+            expect(result).not.to.be.null;
+            expect(result.type).to.be.equal(2);
+        }).timeout(10_000);
+
+        it("should send EIP1559 transaction with `maxFeePerGas` and `maxPriorityFeePerGas` same as provided `gasPrice`", async () => {
+            const tx = await wallet.sendTransaction({
+                to: RECEIVER,
+                value: 7_000_000,
+                gasPrice: BigNumber.from(3_500_000_000),
+            });
+            const result = await tx.wait();
+            expect(result).not.to.be.null;
+            expect(result.type).to.be.equal(2);
+        }).timeout(10_000);
+
+        it("should send legacy transaction when `type = 0`", async () => {
+            const tx = await wallet.sendTransaction({
+                type: 0,
+                to: RECEIVER,
+                value: 7_000_000,
+            });
+            const result = await tx.wait();
+            expect(result).not.to.be.null;
+            expect(result.type).to.be.equal(0);
+        }).timeout(10_000);
     });
 
     describe("#fromMnemonic()", () => {
@@ -231,14 +435,14 @@ describe("Wallet", () => {
     describe("#getDepositTx()", () => {
         it("should return ETH deposit transaction", async () => {
             const tx = {
-                contractAddress: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                contractAddress: ADDRESS,
                 calldata: "0x",
                 l2Value: 7_000_000,
                 l2GasLimit: BigNumber.from("0x08cbaa"),
                 token: "0x0000000000000000000000000000000000000000",
-                to: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                to: ADDRESS,
                 amount: 7_000_000,
-                refundRecipient: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                refundRecipient: ADDRESS,
                 operatorTip: BigNumber.from(0),
                 overrides: {
                     maxFeePerGas: BigNumber.from(1_500_000_010),
@@ -258,14 +462,14 @@ describe("Wallet", () => {
 
         it("should return a deposit transaction with `tx.to == Wallet.getAddress()` when `tx.to` is not specified", async () => {
             const tx = {
-                contractAddress: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                contractAddress: ADDRESS,
                 calldata: "0x",
                 l2Value: 7_000_000,
                 l2GasLimit: BigNumber.from("0x8cbaa"),
                 token: "0x0000000000000000000000000000000000000000",
-                to: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                to: ADDRESS,
                 amount: 7_000_000,
-                refundRecipient: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                refundRecipient: ADDRESS,
                 operatorTip: BigNumber.from(0),
                 overrides: {
                     maxFeePerGas: BigNumber.from(1_500_000_010),
@@ -287,7 +491,7 @@ describe("Wallet", () => {
                 maxFeePerGas: BigNumber.from(1_500_000_010),
                 maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
                 value: BigNumber.from(288_992_000_000_000),
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 to: (await wallet.getL1BridgeContracts()).erc20.address,
             };
             const result = await wallet.getDepositTx({

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -145,7 +145,9 @@ describe("Wallet", () => {
             try {
                 wallet.ethWallet();
             } catch (e) {
-                expect((e as Error).message).to.be.equal("L1 provider missing: use `connectToL1` to specify!");
+                expect((e as Error).message).to.be.equal(
+                    "L1 provider missing: use `connectToL1` to specify!",
+                );
             }
         });
     });
@@ -201,14 +203,14 @@ describe("Wallet", () => {
                 type: 113,
                 from: ADDRESS,
                 nonce: await wallet.getNonce("pending"),
-                data: '0x',
+                data: "0x",
                 chainId: 270,
                 maxFeePerGas: BigNumber.from(3_500_000_000),
                 maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
                 customData: {
                     gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
-                    factoryDeps: []
-                }
+                    factoryDeps: [],
+                },
             };
             const result = await wallet.populateTransaction({
                 to: RECEIVER,
@@ -217,8 +219,8 @@ describe("Wallet", () => {
                 maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
                 customData: {
                     gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
-                    factoryDeps: []
-                }
+                    factoryDeps: [],
+                },
             });
             expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
         });
@@ -230,21 +232,21 @@ describe("Wallet", () => {
                 type: 113,
                 from: ADDRESS,
                 nonce: await wallet.getNonce("pending"),
-                data: '0x',
+                data: "0x",
                 chainId: 270,
                 maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
                 customData: {
                     gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
-                    factoryDeps: []
-                }
+                    factoryDeps: [],
+                },
             };
             const result = await wallet.populateTransaction({
                 to: RECEIVER,
                 value: 7_000_000,
                 maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
                 customData: {
-                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT
-                }
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                },
             });
             expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
         });
@@ -256,21 +258,21 @@ describe("Wallet", () => {
                 type: 113,
                 from: ADDRESS,
                 nonce: await wallet.getNonce("pending"),
-                data: '0x',
+                data: "0x",
                 chainId: 270,
                 maxFeePerGas: BigNumber.from(3_500_000_000),
                 customData: {
                     gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
-                    factoryDeps: []
-                }
+                    factoryDeps: [],
+                },
             };
             const result = await wallet.populateTransaction({
                 to: RECEIVER,
                 value: 7_000_000,
                 maxFeePerGas: BigNumber.from(3_500_000_000),
                 customData: {
-                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT
-                }
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                },
             });
             expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
         });
@@ -315,22 +317,22 @@ describe("Wallet", () => {
         });
 
         it("should return populated legacy transaction when `type = 0`", async () => {
-          const tx = {
-              to: RECEIVER,
-              value: 7_000_000,
-              type: 0,
-              from: ADDRESS,
-              nonce: await wallet.getNonce("pending"),
-              chainId: 270,
-              gasPrice: BigNumber.from(250_000_000),
-          };
-          const result = await wallet.populateTransaction({
-              type: 0,
-              to: RECEIVER,
-              value: 7_000_000,
-          });
-          expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
-      });
+            const tx = {
+                to: RECEIVER,
+                value: 7_000_000,
+                type: 0,
+                from: ADDRESS,
+                nonce: await wallet.getNonce("pending"),
+                chainId: 270,
+                gasPrice: BigNumber.from(250_000_000),
+            };
+            const result = await wallet.populateTransaction({
+                type: 0,
+                to: RECEIVER,
+                value: 7_000_000,
+            });
+            expect(result).to.be.deepEqualExcluding(tx, ["gasLimit"]);
+        });
     });
 
     describe("#sendTransaction()", () => {
@@ -341,8 +343,8 @@ describe("Wallet", () => {
                 maxFeePerGas: BigNumber.from(3_500_000_000),
                 maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
                 customData: {
-                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT
-                }
+                    gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+                },
             });
             const tx = await wallet.sendTransaction(populatedTx);
             const result = await tx.wait();

--- a/tests/unit/signer.test.ts
+++ b/tests/unit/signer.test.ts
@@ -6,12 +6,15 @@ import { ethers, BigNumber } from "ethers";
 const { expect } = chai;
 
 describe("EIP712Signer", () => {
+    const ADDRESS = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+    const RECEIVER = "0xa61464658AfeAf65CccaaFD3a512b69A83B77618";
+
     describe("#getSignInput()", () => {
         it("should return a populated transaction", async () => {
             const tx = {
                 txType: utils.EIP712_TX_TYPE,
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
-                to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+                from: ADDRESS,
+                to: RECEIVER,
                 gasLimit: BigNumber.from(21_000),
                 gasPerPubdataByteLimit: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
                 maxFeePerGas: BigNumber.from(250_000_000),
@@ -26,9 +29,9 @@ describe("EIP712Signer", () => {
 
             const result = EIP712Signer.getSignInput({
                 type: utils.EIP712_TX_TYPE,
-                to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+                to: RECEIVER,
                 value: BigNumber.from(7_000_000),
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 nonce: 0,
                 chainId: 270,
                 gasPrice: BigNumber.from(250_000_000),
@@ -41,8 +44,8 @@ describe("EIP712Signer", () => {
         it("should return a populated transaction with default values", async () => {
             const tx = {
                 txType: utils.EIP712_TX_TYPE,
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
-                to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+                from: ADDRESS,
+                to: RECEIVER,
                 gasLimit: 0,
                 gasPerPubdataByteLimit: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
                 maxFeePerGas: 0,
@@ -57,8 +60,8 @@ describe("EIP712Signer", () => {
 
             const result = EIP712Signer.getSignInput({
                 type: utils.EIP712_TX_TYPE,
-                to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                to: RECEIVER,
+                from: ADDRESS,
             });
             expect(result).to.be.deep.equal(tx);
         });

--- a/tests/unit/signer.test.ts
+++ b/tests/unit/signer.test.ts
@@ -72,7 +72,7 @@ describe("EIP712Signer", () => {
             try {
                 EIP712Signer.getSignedDigest({});
             } catch (e) {
-                expect(e.message).to.be.equal("Transaction chainId isn't set!");
+                expect((e as Error).message).to.be.equal("Transaction chainId isn't set!");
             }
         });
     });

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -3,6 +3,9 @@ import { utils } from "../../src";
 import { ethers, BigNumber } from "ethers";
 
 describe("utils", () => {
+    const ADDRESS = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+    const RECEIVER = "0xa61464658AfeAf65CccaaFD3a512b69A83B77618";
+
     describe("#getHashedL2ToL1Msg()", () => {
         it("should return a hashed L2 to L1 message", async () => {
             const withdrawETHMessage =
@@ -10,7 +13,7 @@ describe("utils", () => {
             const withdrawETHMessageHash =
                 "0x521bd25904766c83fe868d6a29cbffa011afd8a1754f6c9a52b053b693e42f18";
             const result = utils.getHashedL2ToL1Msg(
-                "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                ADDRESS,
                 withdrawETHMessage,
                 0,
             );
@@ -32,7 +35,7 @@ describe("utils", () => {
 
     describe("#createAddress()", () => {
         it("should return the correct address", async () => {
-            const address = utils.createAddress("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049", 1);
+            const address = utils.createAddress(ADDRESS, 1);
             expect(address).to.be.equal("0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021");
         });
     });
@@ -40,7 +43,7 @@ describe("utils", () => {
     describe("#create2Address()", () => {
         it("should return the correct address", async () => {
             const address = utils.create2Address(
-                "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                ADDRESS,
                 "0x010001cb6a6e8d5f6829522f19fa9568660e0a9cd53b2e8be4deb0a679452e41",
                 "0x01",
                 "0x01",
@@ -115,7 +118,7 @@ describe("utils", () => {
             try {
                 utils.serialize({
                     chainId: 270,
-                    from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                    from: ADDRESS,
                     customData: {
                         customSignature: "",
                     },
@@ -131,7 +134,7 @@ describe("utils", () => {
             const result = utils.serialize({
                 type: 113,
                 chainId: 270,
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
             });
             expect(result).to.be.equal(tx);
         });
@@ -146,8 +149,8 @@ describe("utils", () => {
                 {
                     type: 113,
                     chainId: 270,
-                    from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
-                    to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+                    from: ADDRESS,
+                    to: RECEIVER,
                     value: 1_000_000,
                 },
                 signature,
@@ -216,11 +219,11 @@ describe("utils", () => {
                 maxPriorityFeePerGas: BigNumber.from(0),
                 maxFeePerGas: BigNumber.from(0),
                 gasLimit: BigNumber.from(0),
-                to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+                to: RECEIVER,
                 value: BigNumber.from(1000000),
                 data: "0x",
                 chainId: BigNumber.from(270),
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 customData: {
                     gasPerPubdata: BigNumber.from(50000),
                     factoryDeps: [],
@@ -243,11 +246,11 @@ describe("utils", () => {
                 maxPriorityFeePerGas: BigNumber.from(0),
                 maxFeePerGas: BigNumber.from(0),
                 gasLimit: BigNumber.from(0),
-                to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+                to: RECEIVER,
                 value: BigNumber.from(0),
                 data: "0x",
                 chainId: BigNumber.from(270),
-                from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                from: ADDRESS,
                 customData: {
                     gasPerPubdata: BigNumber.from(50000),
                     factoryDeps: [],

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -12,11 +12,7 @@ describe("utils", () => {
                 "0x6c0960f936615cf349d7f6344891b1e7ca7c72883f5dc04900000000000000000000000000000000000000000000000000000001a13b8600";
             const withdrawETHMessageHash =
                 "0x521bd25904766c83fe868d6a29cbffa011afd8a1754f6c9a52b053b693e42f18";
-            const result = utils.getHashedL2ToL1Msg(
-                ADDRESS,
-                withdrawETHMessage,
-                0,
-            );
+            const result = utils.getHashedL2ToL1Msg(ADDRESS, withdrawETHMessage, 0);
             expect(result).to.be.equal(withdrawETHMessageHash);
         });
     });
@@ -188,7 +184,9 @@ describe("utils", () => {
             try {
                 utils.hashBytecode("0x0002");
             } catch (e) {
-                expect((e as Error).message).to.be.equal("The bytecode length in bytes must be divisible by 32!");
+                expect((e as Error).message).to.be.equal(
+                    "The bytecode length in bytes must be divisible by 32!",
+                );
             }
         });
 

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -88,7 +88,7 @@ describe("utils", () => {
             try {
                 await utils.checkBaseCost(baseCost, value);
             } catch (e) {
-                expect(e.message).to.be.equal(
+                expect((e as Error).message).to.be.equal(
                     `The base cost of performing the priority operation is higher than the provided value parameter for the transaction: baseCost: ${baseCost}, provided value: ${value}!`,
                 );
             }
@@ -100,7 +100,7 @@ describe("utils", () => {
             try {
                 utils.serialize({});
             } catch (e) {
-                expect(e.message).to.be.equal("Transaction chainId isn't set!");
+                expect((e as Error).message).to.be.equal("Transaction chainId isn't set!");
             }
         });
 
@@ -108,7 +108,7 @@ describe("utils", () => {
             try {
                 utils.serialize({ chainId: 270 });
             } catch (e) {
-                expect(e.message).to.be.equal(
+                expect((e as Error).message).to.be.equal(
                     "Explicitly providing `from` field is required for EIP712 transactions!",
                 );
             }
@@ -124,7 +124,7 @@ describe("utils", () => {
                     },
                 });
             } catch (e) {
-                expect(e.message).to.be.equal("Empty signatures are not supported");
+                expect((e as Error).message).to.be.equal("Empty signatures are not supported");
             }
         });
 
@@ -188,7 +188,7 @@ describe("utils", () => {
             try {
                 utils.hashBytecode("0x0002");
             } catch (e) {
-                expect(e.message).to.be.equal("The bytecode length in bytes must be divisible by 32!");
+                expect((e as Error).message).to.be.equal("The bytecode length in bytes must be divisible by 32!");
             }
         });
 
@@ -196,7 +196,7 @@ describe("utils", () => {
             try {
                 utils.hashBytecode(`0x${"00020000000000020009000000000002".repeat(2)}`);
             } catch (e) {
-                expect(e.message).to.be.equal(
+                expect((e as Error).message).to.be.equal(
                     `Bytecode can not be longer than ${utils.MAX_BYTECODE_LEN_BYTES} bytes!`,
                 );
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,11 @@
         "preserveSymlinks": true,
         "preserveWatchOutput": true,
 
-        "noImplicitOverride": true
+        "noImplicitOverride": true,
+        "strict": true
     },
-    "files": ["./src/index.ts"]
+    "include": [
+        "./src/index.ts",
+        "tests/**/*.ts"
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,5 @@
         "noImplicitOverride": true,
         "strict": true
     },
-    "include": [
-        "./src/index.ts",
-        "tests/**/*.ts"
-    ]
+    "include": ["./src/index.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
# What :computer: 
* Fix validation errors when populating a transaction when `maxFeePerGas` or `maxPriorityFeePerGas` are set. Populating a transaction calls for `ethers` implementation to check the type of transaction it is, whether it's EIP1559, by checking if `maxFeePerGas` and `maxPriorityFeePerGas` are set. If it is, it doesn't allow `gasPrice` to be present.