### PR TITLE
Ethers V6:  fix example in `Signer.from()` method

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -391,8 +391,8 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    *
    * const ethProvider = new ethers.BrowserProvider(window.ethereum);
    * const ethSigner = provider.getSigner("<ADDRESS>");
-   * const chainId = Number((await Provider.getDefaultProvider(types.Network.Sepolia).getNetwork()).chainId)
-   * const signer = Signer.from(ethSigner as any, chainId)
+   * const chainId = Number((await Provider.getDefaultProvider(types.Network.Sepolia).getNetwork()).chainId);
+   * const signer = Signer.from(ethSigner as any, chainId);
    */
   static from(
     signer: ethers.JsonRpcSigner & {provider: Provider},


### PR DESCRIPTION
# What :computer: 
* Fix example in `Signer.from()` method.