### PR TITLE
Ethers V5: Add `L2VoidSigner` and `L1VoidSigner`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 export * as utils from './utils';
 export * as types from './types';
-export {EIP712Signer, Signer, L1Signer} from './signer';
+export {
+  EIP712Signer,
+  Signer,
+  L1Signer,
+  L2VoidSigner,
+  L1VoidSigner,
+} from './signer';
 export {Wallet} from './wallet';
 export {Web3Provider, Provider} from './provider';
 export {ContractFactory, Contract} from './contract';

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -409,7 +409,7 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * const nonce = await signer.getNonce();
    */
-  async getNonce(blockTag?: BlockTag) {
+  async getNonce(blockTag?: BlockTag): Promise<number> {
     return await this.getTransactionCount(blockTag);
   }
 
@@ -1134,3 +1134,218 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
   }
 }
 /* c8 ignore stop */
+
+/**
+ * A `L2VoidSigner` is a class designed to allow an address to be used in any API which accepts a `Signer`, but for
+ * which there are no credentials available to perform any actual signing.
+ *
+ * This for example allow impersonating an account for the purpose of static calls or estimating gas, but does not
+ * allow sending transactions.
+ *
+ * Provides only L2 operations.
+ *
+ * @see {@link L1VoidSigner} for L1 operations.
+ */
+export class L2VoidSigner extends AdapterL2(ethers.VoidSigner) {
+  public override provider!: Provider;
+
+  override _signerL2() {
+    return this;
+  }
+
+  override _providerL2(): Provider {
+    return this.provider;
+  }
+
+  /**
+   * Connects to the L2 network using the `provider`.
+   *
+   * @param provider The provider instance for connecting to a L2 network.
+   *
+   * @example
+   *
+   * import { Provider, L2VoidSigner, types } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   *
+   * let signer = new L2VoidSigner("<ADDRESS>");
+   * signer = signer.connect(provider);
+   */
+  override connect(provider: Provider): L2VoidSigner {
+    return new L2VoidSigner(this.address, provider);
+  }
+
+  /**
+   * Designed for users who prefer a simplified approach by providing only the necessary data to create a valid transaction.
+   * The only required fields are `transaction.to` and either `transaction.data` or `transaction.value` (or both, if the method is payable).
+   * Any other fields that are not set will be prepared by this method.
+   *
+   * @param transaction The transaction request that needs to be populated.
+   *
+   * @example
+   *
+   * import { Provider, L2VoidSigner, types } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const signer = new L2VoidSigner("<ADDRESS>", provider);
+   *
+   * const populatedTx = await signer.populateTransaction({
+   *   to: RECEIVER,
+   *   value: 7_000_000,
+   *   maxFeePerGas: BigNumber.from(3_500_000_000),
+   *   maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+   *   customData: {
+   *     gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+   *     factoryDeps: [],
+   *   },
+   * });
+   */
+  override async populateTransaction(
+    transaction: TransactionRequest
+  ): Promise<TransactionRequest> {
+    if (
+      (!transaction.type || transaction.type !== EIP712_TX_TYPE) &&
+      !transaction.customData
+    ) {
+      return await super.populateTransaction(transaction);
+    }
+    transaction.type = EIP712_TX_TYPE;
+    const populated = await super.populateTransaction(transaction);
+
+    populated.type = EIP712_TX_TYPE;
+    populated.value ??= 0;
+    populated.data ??= '0x';
+    populated.customData = this._fillCustomData(transaction.customData ?? {});
+    if (!populated.maxFeePerGas && !populated.maxPriorityFeePerGas) {
+      populated.gasPrice = await this.provider.getGasPrice();
+    }
+    return populated;
+  }
+
+  /**
+   * Get the number of transactions ever sent for account, which is used as the `nonce` when sending a transaction.
+   *
+   * @param [blockTag] The block tag to query. If provided, the transaction count is as of that block.
+   *
+   * @example
+   *
+   * import { Provider, L2VoidSigner, types } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const signer = new L2VoidSigner("<ADDRESS>", provider);
+   *
+   * const nonce = await signer.getNonce();
+   */
+  async getNonce(blockTag?: BlockTag): Promise<number> {
+    return await this.getTransactionCount(blockTag);
+  }
+}
+
+/**
+ * A `L1VoidSigner` is a class designed to allow an address to be used in any API which accepts a `Signer`, but for
+ * which there are no credentials available to perform any actual signing.
+ *
+ * This for example allow impersonating an account for the purpose of static calls or estimating gas, but does not
+ * allow sending transactions.
+ *
+ * Provides only L1 operations.
+ *
+ * @see {@link L2VoidSigner} for L2 operations.
+ */
+export class L1VoidSigner extends AdapterL1(ethers.VoidSigner) {
+  public providerL2?: Provider;
+
+  override _providerL2(): Provider {
+    if (!this.providerL2) {
+      throw new Error('L2 provider missing: use `connectToL2` to specify!');
+    }
+    return this.providerL2;
+  }
+
+  override _providerL1(): ethers.providers.Provider {
+    return this.provider as ethers.providers.Provider;
+  }
+
+  override _signerL1() {
+    return this;
+  }
+
+  /**
+   * @param address The address of the account.
+   * @param providerL1 The provider instance for connecting to a L1 network.
+   * @param providerL2 The provider instance for connecting to a L2 network.
+   *
+   * @example
+   *
+   * import { Provider, L1VoidSigner, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   * const signer = new L1VoidSigner("<ADDRESS>", ethProvider, provider);
+   */
+  constructor(
+    address: string,
+    providerL1?: ethers.providers.Provider,
+    providerL2?: Provider
+  ) {
+    super(address, providerL1);
+    this.providerL2 = providerL2;
+  }
+
+  /**
+   * Connects to the L1 network using the `provider`.
+   *
+   * @param provider The provider instance for connecting to a L1 network.
+   *
+   * @example
+   *
+   * import { L1VoidSigner } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   *
+   * let singer = new L1VoidSigner("<ADDRESS>);
+   * singer = singer.connect(ethProvider);
+   */
+  override connect(provider: ethers.providers.Provider): L1VoidSigner {
+    return new L1VoidSigner(this.address, provider);
+  }
+
+  /**
+   * Connects to the L2 network using the `provider`.
+   *
+   * @param provider The provider instance for connecting to a L2 network.
+   *
+   * @example
+   *
+   * import { Provider, L1VoidSigner, types } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * let signer = new L1VoidSigner("<ADDRESS>");
+   * signer = signer.connectToL2(provider);
+   */
+  connectToL2(provider: Provider): this {
+    this.providerL2 = provider;
+    return this;
+  }
+
+  /**
+   * Get the number of transactions ever sent for account, which is used as the `nonce` when sending a transaction.
+   *
+   * @param [blockTag] The block tag to query. If provided, the transaction count is as of that block.
+   *
+   * @example
+   *
+   * import { L1VoidSigner } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   * const signer = new L1VoidSigner("<ADDRESS>", ethProvider);
+   *
+   * const nonce = await signer.getNonce();
+   */
+  async getNonce(blockTag?: BlockTag): Promise<number> {
+    return await this.getTransactionCount(blockTag);
+  }
+}

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -324,10 +324,8 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    * const provider = new Web3Provider(window.ethereum);
    * const signer = provider.getSigner();
    *
-   * const recipient = Wallet.createRandom();
-   *
    * const transferHandle = signer.transfer({
-   *   to: recipient.address,
+   *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    * });
    *
@@ -346,10 +344,8 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    * const provider = new Web3Provider(window.ethereum);
    * const signer = provider.getSigner();
    *
-   * const recipient = Wallet.createRandom();
-   *
    * const transferHandle = signer.transfer({
-   *   to: recipient.address,
+   *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
@@ -1190,7 +1186,7 @@ export class L2VoidSigner extends AdapterL2(ethers.VoidSigner) {
    * const signer = new L2VoidSigner("<ADDRESS>", provider);
    *
    * const populatedTx = await signer.populateTransaction({
-   *   to: RECEIVER,
+   *   to: Wallet.createRandom().address,
    *   value: 7_000_000,
    *   maxFeePerGas: BigNumber.from(3_500_000_000),
    *   maxPriorityFeePerGas: BigNumber.from(2_000_000_000),

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -838,10 +838,8 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const recipient = Wallet.createRandom();
-   *
    * const transferHandle = await wallet.transfer({
-   *   to: recipient.address,
+   *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    * });
    *
@@ -860,10 +858,8 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const recipient = Wallet.createRandom();
-   *
    * const transferHandle = await wallet.transfer({
-   *   to: recipient.address,
+   *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
@@ -1094,6 +1090,22 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * Any other fields that are not set will be prepared by this method.
    *
    * @param transaction The transaction request that needs to be populated.
+   *
+   * @example
+   *
+   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
+   *
+   * const populatedTx = await wallet.populateTransaction({
+   *   to: Wallet.createRandom().address,
+   *   value: 7_000_000,
+   * });
    */
   override async populateTransaction(
     transaction: TransactionRequest
@@ -1123,6 +1135,23 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * @param transaction The transaction request that needs to be signed.
    *
    * @throws {Error} If `transaction.from` is mismatched from the private key.
+   *
+   * @example
+   *
+   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
+   *
+   * const tx = await wallet.signTransaction({
+   *   type: utils.EIP712_TX_TYPE,
+   *   to: Wallet.createRandom().address,
+   *   value: BigNumber.from(7_000_000_000),
+   * });
    */
   override async signTransaction(
     transaction: TransactionRequest
@@ -1142,6 +1171,28 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * @param transaction The transaction request that needs to be broadcast to the network.
    *
    * @throws {Error} If `transaction.from` is mismatched from the private key.
+   *
+   * @example
+   *
+   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
+   *
+   * const tx = await wallet.sendTransaction({
+   *   to: RECEIVER,
+   *   value: 7_000_000,
+   *   maxFeePerGas: BigNumber.from(3_500_000_000),
+   *   maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+   *   customData: {
+   *     gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+   *   },
+   * });
+   * await tx.wait();
    */
   override async sendTransaction(
     transaction: ethers.providers.TransactionRequest

--- a/tests/integration/signer.test.ts
+++ b/tests/integration/signer.test.ts
@@ -1,0 +1,790 @@
+import * as chai from 'chai';
+import '../custom-matchers';
+import {Provider, utils, Wallet, L2VoidSigner, L1VoidSigner} from '../../src';
+import {ethers, BigNumber} from 'ethers';
+
+const {expect} = chai;
+
+describe('L2VoidSigner', () => {
+  const ADDRESS = '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049';
+  const RECEIVER = '0xa61464658AfeAf65CccaaFD3a512b69A83B77618';
+
+  const provider = Provider.getDefaultProvider();
+  const signer = new L2VoidSigner(ADDRESS, provider);
+
+  describe('#constructor()', () => {
+    it('`L2VoidSigner(address, provider)` should return a `L2VoidSigner` with L2 provider', async () => {
+      const signer = new L2VoidSigner(ADDRESS, provider);
+
+      expect(signer.address).to.be.equal(ADDRESS);
+      expect(signer.provider).to.be.equal(provider);
+    });
+
+    it('`L2VoidSigner(address)` should return a `L2VoidSigner` without L2 provider', async () => {
+      const signer = new L2VoidSigner(ADDRESS);
+
+      expect(signer.address).to.be.equal(ADDRESS);
+      expect(signer.provider).to.be.null;
+    });
+  });
+
+  describe('#getBalance()', () => {
+    it('should return the `L2VoidSigner` balance', async () => {
+      const result = await signer.getBalance();
+      expect(result.gt(0)).to.be.true;
+    });
+  });
+
+  describe('#getAllBalances()', () => {
+    it('should return all balances', async () => {
+      const result = await signer.getAllBalances();
+      expect(Object.keys(result)).to.have.lengthOf(2);
+    });
+  });
+
+  describe('#getL2BridgeContracts()', () => {
+    it('should return a L2 bridge contracts', async () => {
+      const result = await signer.getL2BridgeContracts();
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#getAddress()', () => {
+    it('should return a `L2VoidSigner` address', async () => {
+      const result = await signer.getAddress();
+      expect(result).to.be.equal(ADDRESS);
+    });
+  });
+
+  describe('#connect()', () => {
+    it('should return a `L2VoidSigner` with provided `provider` as L2 provider', async () => {
+      let signer = new L2VoidSigner(ADDRESS);
+      signer = signer.connect(provider);
+
+      expect(signer.address).to.be.equal(ADDRESS);
+      expect(signer.provider).to.be.equal(provider);
+    });
+  });
+
+  describe('#getDeploymentNonce()', () => {
+    it('should return a deployment nonce', async () => {
+      const result = await signer.getDeploymentNonce();
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#populateTransaction()', () => {
+    it('should return populated transaction with default values if are omitted', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 2,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 270,
+        maxFeePerGas: BigNumber.from(2_000_000_000),
+        maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated transaction when `maxFeePerGas` and `maxPriorityFeePerGas` and `customData` are provided', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 113,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        data: '0x',
+        chainId: 270,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          factoryDeps: [],
+        },
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          factoryDeps: [],
+        },
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated transaction when `maxPriorityFeePerGas` and `customData` are provided', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 113,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        data: '0x',
+        chainId: 270,
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          factoryDeps: [],
+        },
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+        },
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated transaction when `maxFeePerGas` and `customData` are provided', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 113,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        data: '0x',
+        chainId: 270,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          factoryDeps: [],
+        },
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+        },
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated EIP1559 transaction when `maxFeePerGas` and `maxPriorityFeePerGas` are provided', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 2,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 270,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated EIP1559 transaction with `maxFeePerGas` and `maxPriorityFeePerGas` same as provided `gasPrice`', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 2,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 270,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(3_500_000_000),
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        gasPrice: BigNumber.from(3_500_000_000),
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated legacy transaction when `type = 0`', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 0,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 270,
+        gasPrice: BigNumber.from(250_000_000),
+      };
+      const result = await signer.populateTransaction({
+        type: 0,
+        to: RECEIVER,
+        value: 7_000_000,
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+  });
+
+  describe('#sendTransaction()', () => {
+    it('should throw an error when trying to send transaction', async () => {
+      try {
+        await signer.sendTransaction({
+          to: RECEIVER,
+          value: 7_000_000,
+          maxFeePerGas: BigNumber.from(3_500_000_000),
+          maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(10_000);
+  });
+
+  describe('#withdraw()', () => {
+    it('should throw an error when tyring to withdraw assets', async () => {
+      try {
+        await signer.withdraw({
+          token: utils.ETH_ADDRESS,
+          to: await signer.getAddress(),
+          amount: 7_000_000_000,
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(25_000);
+  });
+
+  describe('#transfer()', () => {
+    it('should throw an error when tyring to transfer assets', async () => {
+      try {
+        await signer.transfer({
+          token: utils.ETH_ADDRESS,
+          to: RECEIVER,
+          amount: 7_000_000_000,
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(25_000);
+  });
+
+  describe('#signTransaction()', () => {
+    it('should throw an error when trying to sign transaction', async () => {
+      try {
+        await signer.signTransaction({
+          type: 2,
+          to: RECEIVER,
+          value: BigNumber.from(7_000_000_000),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(25_000);
+  });
+});
+
+describe('L1VoidSigner', () => {
+  const ADDRESS = '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049';
+  const RECEIVER = '0xa61464658AfeAf65CccaaFD3a512b69A83B77618';
+
+  const provider = Provider.getDefaultProvider();
+  const ethProvider = ethers.getDefaultProvider('http://localhost:8545');
+  const signer = new L1VoidSigner(ADDRESS, ethProvider, provider);
+
+  const TOKENS_L1 = require('../tokens.json');
+  const DAI_L1 = TOKENS_L1[0].address;
+
+  describe('#constructor()', () => {
+    it('`L1VoidSigner(privateKey, providerL1, providerL2)` should return a `L1VoidSigner` with L1 and L2 provider', async () => {
+      const signer = new L1VoidSigner(ADDRESS, ethProvider, provider);
+
+      expect(signer.address).to.be.equal(ADDRESS);
+      expect(signer.provider).to.be.equal(ethProvider);
+      expect(signer.providerL2).to.be.equal(provider);
+    });
+
+    it('`L1VoidSigner(privateKey, providerL1)` should return a `L1VoidSigner` with L1 provider', async () => {
+      const signer = new L1VoidSigner(ADDRESS, ethProvider);
+
+      expect(signer.address).to.be.equal(ADDRESS);
+      expect(signer.provider).to.be.equal(ethProvider);
+      expect(signer.providerL2).to.be.undefined;
+    });
+
+    it('`L1VoidSigner(privateKey)` should return a `L1VoidSigner` without providers', async () => {
+      const signer = new L1VoidSigner(ADDRESS);
+
+      expect(signer.address).to.be.equal(ADDRESS);
+      expect(signer.provider).to.be.null;
+      expect(signer.providerL2).to.be.undefined;
+    });
+  });
+
+  describe('#getMainContract()', () => {
+    it('should return the main contract', async () => {
+      const result = await signer.getMainContract();
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#getL1BridgeContracts()', () => {
+    it('should return a L1 bridge contracts', async () => {
+      const result = await signer.getL1BridgeContracts();
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#getBalanceL1()', () => {
+    it('should return a L1 balance', async () => {
+      const result = await signer.getBalanceL1();
+      expect(result.gt(0)).to.be.true;
+    });
+  });
+
+  describe('#getAllowanceL1()', () => {
+    it('should return allowance of L1 token', async () => {
+      const result = await signer.getAllowanceL1(DAI_L1);
+      expect(result.gte(0)).to.be.true;
+    });
+  });
+
+  describe('#l2TokenAddress()', () => {
+    it('should return the L2 ETH address', async () => {
+      const result = await signer.l2TokenAddress(utils.ETH_ADDRESS);
+      expect(result).to.be.equal(utils.ETH_ADDRESS);
+    });
+
+    it('should return the L2 DAI address', async () => {
+      const result = await signer.l2TokenAddress(DAI_L1);
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#approveERC20()', () => {
+    it('should throw an error when approving token', async () => {
+      try {
+        await signer.approveERC20(utils.ETH_ADDRESS, 5);
+      } catch (e) {
+        expect((e as Error).message).to.be.equal(
+          "ETH token can't be approved! The address of the token does not exist on L1."
+        );
+      }
+    }).timeout(10_000);
+  });
+
+  describe('#getBaseCost()', () => {
+    it('should return base cost of L1 transaction', async () => {
+      const result = await signer.getBaseCost({gasLimit: 100_000});
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#getBalance()', () => {
+    it('should return the `L1VoidSigner` balance', async () => {
+      const result = await signer.getBalance();
+      expect(result.gt(0)).to.be.true;
+    });
+  });
+
+  describe('#getAddress()', () => {
+    it('should return a `Wallet` address', async () => {
+      const result = await signer.getAddress();
+      expect(result).to.be.equal(ADDRESS);
+    });
+  });
+
+  describe('#connect()', () => {
+    it('should return a `L1VoidSigner` with provided `provider` as L1 provider', async () => {
+      let singer = new L1VoidSigner(ADDRESS);
+      singer = singer.connect(ethProvider);
+      expect(singer.address).to.be.equal(ADDRESS);
+      expect(singer.provider).to.be.equal(ethProvider);
+    });
+  });
+
+  describe('#connectL2()', () => {
+    it('should return a `L1VoidSigner` with provided `provider` as L2 provider', async () => {
+      let singer = new L1VoidSigner(ADDRESS);
+      singer = singer.connectToL2(provider);
+      expect(singer.address).to.be.equal(ADDRESS);
+      expect(singer.providerL2).to.be.equal(provider);
+    });
+  });
+
+  describe('#populateTransaction()', () => {
+    it('should return populated transaction with default values if are omitted', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 2,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 9,
+        maxFeePerGas: BigNumber.from(1_500_000_014),
+        maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated EIP1559 transaction when `maxFeePerGas` and `maxPriorityFeePerGas` are provided', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 2,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 9,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated EIP1559 transaction with `maxFeePerGas` and `maxPriorityFeePerGas` same as provided `gasPrice`', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 2,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 9,
+        maxFeePerGas: BigNumber.from(3_500_000_000),
+        maxPriorityFeePerGas: BigNumber.from(3_500_000_000),
+      };
+      const result = await signer.populateTransaction({
+        to: RECEIVER,
+        value: 7_000_000,
+        gasPrice: BigNumber.from(3_500_000_000),
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+
+    it('should return populated legacy transaction when `type = 0`', async () => {
+      const tx = {
+        to: RECEIVER,
+        value: 7_000_000,
+        type: 0,
+        from: ADDRESS,
+        nonce: await signer.getNonce('pending'),
+        chainId: 9,
+        gasPrice: BigNumber.from(1_500_000_007),
+      };
+      const result = await signer.populateTransaction({
+        type: 0,
+        to: RECEIVER,
+        value: 7_000_000,
+      });
+      expect(result).to.be.deepEqualExcluding(tx, ['gasLimit']);
+    });
+  });
+
+  describe('#sendTransaction()', () => {
+    it('should throw an error when trying to send transaction', async () => {
+      try {
+        await signer.sendTransaction({
+          to: RECEIVER,
+          value: 7_000_000,
+          maxFeePerGas: BigNumber.from(3_500_000_000),
+          maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(10_000);
+  });
+
+  describe('#getDepositTx()', () => {
+    it('should return ETH deposit transaction', async () => {
+      const tx = {
+        contractAddress: ADDRESS,
+        calldata: '0x',
+        l2Value: 7_000_000,
+        l2GasLimit: BigNumber.from('0x08cbaa'),
+        token: '0x0000000000000000000000000000000000000000',
+        to: ADDRESS,
+        amount: 7_000_000,
+        refundRecipient: ADDRESS,
+        operatorTip: BigNumber.from(0),
+        overrides: {
+          maxFeePerGas: BigNumber.from(1_500_000_010),
+          maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+          value: BigNumber.from(288_213_007_000_000),
+        },
+        gasPerPubdataByte: 800,
+      };
+      const result = await signer.getDepositTx({
+        token: utils.ETH_ADDRESS,
+        to: await signer.getAddress(),
+        amount: 7_000_000,
+        refundRecipient: await signer.getAddress(),
+      });
+      expect(result).to.be.deep.equal(tx);
+    });
+
+    it('should return a deposit transaction with `tx.to == Wallet.getAddress()` when `tx.to` is not specified', async () => {
+      const tx = {
+        contractAddress: ADDRESS,
+        calldata: '0x',
+        l2Value: 7_000_000,
+        l2GasLimit: BigNumber.from('0x8cbaa'),
+        token: '0x0000000000000000000000000000000000000000',
+        to: ADDRESS,
+        amount: 7_000_000,
+        refundRecipient: ADDRESS,
+        operatorTip: BigNumber.from(0),
+        overrides: {
+          maxFeePerGas: BigNumber.from(1_500_000_010),
+          maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+          value: BigNumber.from(288_213_007_000_000),
+        },
+        gasPerPubdataByte: 800,
+      };
+      const result = await signer.getDepositTx({
+        token: utils.ETH_ADDRESS,
+        amount: 7_000_000,
+        refundRecipient: await signer.getAddress(),
+      });
+      expect(result).to.be.deep.equal(tx);
+    });
+
+    it('should return DAI deposit transaction', async () => {
+      const tx = {
+        maxFeePerGas: BigNumber.from(1_500_000_010),
+        maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+        value: BigNumber.from(288_992_000_000_000),
+        from: ADDRESS,
+        to: (await signer.getL1BridgeContracts()).erc20.address,
+      };
+      const result = await signer.getDepositTx({
+        token: DAI_L1,
+        to: await signer.getAddress(),
+        amount: 5,
+        refundRecipient: await signer.getAddress(),
+      });
+      result.to = result.to.toLowerCase();
+      expect(result).to.be.deepEqualExcluding(tx, ['data']);
+    });
+  });
+
+  describe('#estimateGasDeposit()', () => {
+    it('should return gas estimation for ETH deposit transaction', async () => {
+      const result = await signer.estimateGasDeposit({
+        token: utils.ETH_ADDRESS,
+        to: await signer.getAddress(),
+        amount: 5,
+        refundRecipient: await signer.getAddress(),
+      });
+      expect(result.eq(BigNumber.from(132_711))).to.be.true;
+    });
+
+    it('should return gas estimation for DAI deposit transaction', async () => {
+      const wallet = new Wallet(
+        '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110',
+        provider,
+        ethProvider
+      );
+      const tx = await wallet.approveERC20(DAI_L1, 5);
+      await tx.wait();
+
+      const result = await signer.estimateGasDeposit({
+        token: DAI_L1,
+        to: await signer.getAddress(),
+        amount: 5,
+        refundRecipient: await signer.getAddress(),
+      });
+      expect(result.eq(BigNumber.from(253_418))).to.be.true;
+    }).timeout(10_000);
+  });
+
+  describe('#deposit()', () => {
+    it('should throw an error when trying to deposit assets', async () => {
+      try {
+        await signer.deposit({
+          token: utils.ETH_ADDRESS,
+          to: await signer.getAddress(),
+          amount: 7_000_000_000,
+          refundRecipient: await signer.getAddress(),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(10_000);
+  });
+
+  describe('#claimFailedDeposit()', () => {
+    it('should throw an error when trying to claim successful deposit', async () => {
+      try {
+        const response = await signer.deposit({
+          token: utils.ETH_ADDRESS,
+          to: await signer.getAddress(),
+          amount: 7_000_000_000,
+          refundRecipient: await signer.getAddress(),
+        });
+
+        const tx = await response.waitFinalize();
+        await signer.claimFailedDeposit(tx.transactionHash);
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(30_000);
+  });
+
+  describe('#getFullRequiredDepositFee()', () => {
+    it('should return fee for ETH token deposit', async () => {
+      const feeData = {
+        baseCost: BigNumber.from(285_096_500_000_000),
+        l1GasLimit: BigNumber.from(132_711),
+        l2GasLimit: BigNumber.from('0x08b351'),
+        maxFeePerGas: BigNumber.from(1_500_000_010),
+        maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+      };
+      const result = await signer.getFullRequiredDepositFee({
+        token: utils.ETH_ADDRESS,
+        to: await signer.getAddress(),
+      });
+      expect(result).to.be.deep.equal(feeData);
+    });
+
+    it('should throw an error when there is not enough allowance to cover the deposit', async () => {
+      try {
+        await signer.getFullRequiredDepositFee({
+          token: DAI_L1,
+          to: await signer.getAddress(),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.be.equal(
+          'Not enough allowance to cover the deposit!'
+        );
+      }
+    }).timeout(10_000);
+
+    it('should return fee for DAI token deposit', async () => {
+      const feeData = {
+        baseCost: BigNumber.from(288_992_000_000_000),
+        l1GasLimit: BigNumber.from(253_177),
+        l2GasLimit: BigNumber.from('0x08d1c0'),
+        maxFeePerGas: BigNumber.from(1_500_000_010),
+        maxPriorityFeePerGas: BigNumber.from(1_500_000_000),
+      };
+
+      // const wallet = new Wallet(
+      //   "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110",
+      //   provider,
+      //   ethProvider
+      // );
+      // const tx = await wallet.approveERC20(DAI_L1, 5);
+      // await tx.wait();
+
+      const result = await signer.getFullRequiredDepositFee({
+        token: DAI_L1,
+        to: await signer.getAddress(),
+      });
+      expect(result).to.be.deep.equal(feeData);
+    }).timeout(10_000);
+
+    it('should throw an error when there is not enough balance for the deposit', async () => {
+      try {
+        const randomSigner = new L1VoidSigner(
+          ethers.Wallet.createRandom().address,
+          ethProvider,
+          provider
+        );
+
+        await randomSigner.getFullRequiredDepositFee({
+          token: DAI_L1,
+          to: await randomSigner.getAddress(),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.include(
+          'Not enough balance for deposit!'
+        );
+      }
+    }).timeout(10_000);
+  });
+
+  describe('#getRequestExecuteTx()', () => {
+    it('should return request execute transaction', async () => {
+      const result = await signer.getRequestExecuteTx({
+        contractAddress: await provider.getMainContractAddress(),
+        calldata: '0x',
+        l2Value: 7_000_000_000,
+      });
+      expect(result).not.to.be.null;
+    });
+  });
+
+  describe('#estimateGasRequestExecute()', () => {
+    it('should return gas estimation for request execute transaction', async () => {
+      const result = await signer.estimateGasRequestExecute({
+        contractAddress: await provider.getMainContractAddress(),
+        calldata: '0x',
+        l2Value: 7_000_000_000,
+      });
+      expect(result.isZero()).to.be.false;
+    });
+  });
+
+  describe('#requestExecute()', () => {
+    it('should request transaction execution on L2 network', async () => {
+      try {
+        await signer.requestExecute({
+          contractAddress: await provider.getMainContractAddress(),
+          calldata: '0x',
+          l2Value: 7_000_000_000,
+          l2GasLimit: 900_000,
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(10_000);
+  });
+
+  describe('#signTransaction()', () => {
+    it('should throw an error when trying to send transaction', async () => {
+      try {
+        await signer.sendTransaction({
+          to: RECEIVER,
+          value: 7_000_000,
+          maxFeePerGas: BigNumber.from(3_500_000_000),
+          maxPriorityFeePerGas: BigNumber.from(2_000_000_000),
+        });
+      } catch (e) {
+        expect((e as Error).message).to.contain(
+          'VoidSigner cannot sign transactions'
+        );
+      }
+    }).timeout(10_000);
+  });
+});

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -114,7 +114,7 @@ describe('Wallet', () => {
   });
 
   describe('#getAllBalances()', () => {
-    it('should return all balance', async () => {
+    it('should return all balances', async () => {
       const result = await wallet.getAllBalances();
       expect(Object.keys(result)).to.have.lengthOf(2);
     });


### PR DESCRIPTION
# What :computer: 
* Add `L2VoidSigner` and `L1VoidSigner`.

# Why :hand:
In certain scenarios, you may not possess the private key of an account but have its address and wish to utilize zksync read operations (such as `getFullDepositFee`, `isWithdrawalFinalized`, etc.). Currently, all signers (`Wallet`, `Signer`, `L1Signer`, and `EIP712Signer`) require a private key to function, and there is no way to bypass this requirement.

One approach is to modify Adapters' read operations to consider the `overrides.from` field as the account initiating the operation. However, this conflicts with the design of signers. All signers are intended to possess a private key, and the initiator of all operations is the account associated with that private key. The code is structured accordingly, and accommodating `overrides.from` would necessitate extensive changes, which goes against the intended design.

Another approach is to extend `ethers.VoidSigner`. `VoidSigner` itself only contains an address, not a private key, and is used solely for performing read-only operations (estimations, calls, etc.). However, `VoidSigner`'s design has problems. Many methods will inevitably fail due to the absence of a private key, such as `signTransaction`, `signMessage`, `signTypedData`, etc. This suggests that the current abstraction is flawed, as these broken methods should not be part of the API. There should be a separate read-only abstraction, for example, `Caller`, and a distinct abstraction `Signer` extending `Caller`. `VoidSigner` could be replaced by `Caller` under this model. Attempts were made to implement this separation in the `zksync-ethers` SDK by dividing `AdapterL1` into `ReadAdapterL1` and having `AdapterL1` extend `ReadAdapterL1` (similarly with `AdapterL2`). However, this is not feasible with the current design. Ultimately, there is an incentive to refactor the SDK to address these issues.

This change implements the second approach, resulting in the creation of `L2VoidSigner` (providing L2 zksync features) and `L1VoidSigner` (providing L1 zksync features).
