### PR TITLE
Ethers V6: Remove support from `AdapterL1.getFullRequiredDepositFee` work wiith `overrides`

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -576,8 +576,8 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
       tx.gasPerPubdataByte ??= REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT;
 
       let l2GasLimit: bigint;
-      const bridgeContracts = await this.getL1BridgeContracts();
       if (tx.bridgeAddress) {
+        const bridgeContracts = await this.getL1BridgeContracts();
         const customBridgeData =
           tx.customBridgeData ??
           (await bridgeContracts.weth.getAddress()) === tx.bridgeAddress
@@ -617,9 +617,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
         tx.gasPerPubdataByte
       );
 
-      const selfBalanceETH = tx.overrides.from
-        ? await this._providerL1().getBalance(tx.overrides.from)
-        : await this.getBalanceL1();
+      const selfBalanceETH = await this.getBalanceL1();
 
       // We could zero in, because the final fee will anyway be bigger than
       if (baseCost >= selfBalanceETH + dummyAmount) {
@@ -646,20 +644,8 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
         amountForEstimate = dummyAmount;
       } else {
         amountForEstimate = dummyAmount;
-        let allowance: bigint;
-        if (tx.overrides.from) {
-          const erc20contract = IERC20__factory.connect(
-            tx.token,
-            this._providerL1()
-          );
-          allowance = await erc20contract.allowance(
-            tx.overrides.from,
-            await bridgeContracts.erc20.getAddress()
-          );
-        } else {
-          allowance = await this.getAllowanceL1(tx.token);
-        }
-        if (allowance < amountForEstimate) {
+
+        if ((await this.getAllowanceL1(tx.token)) < amountForEstimate) {
           throw new Error('Not enough allowance to cover the deposit!');
         }
       }

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -722,54 +722,6 @@ describe('Wallet', () => {
         );
       }
     }).timeout(10_000);
-
-    it('should estimate a fee for ETH when `from` is used in overrides', async () => {
-      const feeData = {
-        baseCost: 311_192_000_000_000n,
-        l1GasLimit: 135_759n,
-        l2GasLimit: '0x97f30',
-        maxFeePerGas: 1_500_000_010n,
-        maxPriorityFeePerGas: 1_500_000_000n,
-      };
-
-      const randomWallet = new Wallet(
-        ethers.Wallet.createRandom().privateKey,
-        provider,
-        ethProvider
-      );
-      const result = await randomWallet.getFullRequiredDepositFee({
-        token: utils.ETH_ADDRESS,
-        to: await wallet.getAddress(),
-        overrides: {from: ADDRESS},
-      });
-      expect(result).to.be.deepEqualExcluding(feeData, ['l1GasLimit']);
-    }).timeout(10_000);
-
-    it('should estimate a fee for DAI when `from` is used in overrides', async () => {
-      const feeData = {
-        baseCost: 288_992_000_000_000n,
-        l1GasLimit: 253_177n,
-        l2GasLimit: '0x8d1c0',
-        maxFeePerGas: 1_500_000_010n,
-        maxPriorityFeePerGas: 1_500_000_000n,
-      };
-
-      const randomWallet = new Wallet(
-        ethers.Wallet.createRandom().privateKey,
-        provider,
-        ethProvider
-      );
-
-      const tx = await wallet.approveERC20(DAI_L1, 5);
-      await tx.wait();
-
-      const result = await randomWallet.getFullRequiredDepositFee({
-        token: DAI_L1,
-        to: await wallet.getAddress(),
-        overrides: {from: ADDRESS},
-      });
-      expect(result).to.be.deep.equal(feeData);
-    }).timeout(10_000);
   });
 
   describe('#withdraw()', () => {


### PR DESCRIPTION

# What :computer: 
This reverts commit `9feb1e136335f31b7eda3b2e9ef664b1e29ad366`.


# Why :hand:
Remove support from `AdapterL1.getFullRequiredDepositFee` for considering `overrides.from` as the initiator of the operation. This functionality was previously used to calculate the full deposit fee for accounts whose private key is unknown. However, this feature is no longer necessary because `L1VoidSigner.getFullRequiredDepositFee` is specifically designed to handle such cases.
