### PR TITLE
Ethers V5:  Replace `require` with `import`

### DIFF
--- a/src/paymaster-utils.ts
+++ b/src/paymaster-utils.ts
@@ -8,13 +8,13 @@ import {
   PaymasterParams,
 } from './types';
 
+import IPaymasterFlowABI from '../abi/IPaymasterFlow.json';
+
 /**
  * The ABI for the `IPaymasterFlow` interface, which is utilized for encoding input parameters for paymaster flows.
  * @constant
  */
-export const PAYMASTER_FLOW_ABI = new ethers.utils.Interface(
-  require('../abi/IPaymasterFlow.json')
-);
+export const PAYMASTER_FLOW_ABI = new ethers.utils.Interface(IPaymasterFlowABI);
 
 /**
  * Returns encoded input for an approval-based paymaster.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,65 +19,62 @@ import {AbiCoder} from 'ethers/lib/utils';
 export * from './paymaster-utils';
 export {EIP712_TYPES} from './signer';
 
+import IZkSyncABI from '../abi/IZkSync.json';
+import IContractDeployerABI from '../abi/IContractDeployer.json';
+import IL1MessengerABI from '../abi/IL1Messenger.json';
+import IERC20ABI from '../abi/IERC20.json';
+import IERC1271ABI from '../abi/IERC1271.json';
+import IL1BridgeABI from '../abi/IL1Bridge.json';
+import IL2BridgeABI from '../abi/IL2Bridge.json';
+import INonceHolderABI from '../abi/INonceHolder.json';
+
 /**
  * The ABI for the `ZkSync` interface.
  * @constant
  */
-export const ZKSYNC_MAIN_ABI = new utils.Interface(
-  require('../abi/IZkSync.json')
-);
+export const ZKSYNC_MAIN_ABI = new utils.Interface(IZkSyncABI);
 
 /**
  * The ABI for the `IContractDeployer` interface, which is utilized for deploying smart contracts.
  * @constant
  */
-export const CONTRACT_DEPLOYER = new utils.Interface(
-  require('../abi/IContractDeployer.json')
-);
+export const CONTRACT_DEPLOYER = new utils.Interface(IContractDeployerABI);
 
 /**
  * The ABI for the `IL1Messenger` interface, which is utilized for sending messages from the L2 to L1.
  * @constant
  */
-export const L1_MESSENGER = new utils.Interface(
-  require('../abi/IL1Messenger.json')
-);
+export const L1_MESSENGER = new utils.Interface(IL1MessengerABI);
 
 /**
  * The ABI for the `IERC20` interface, which is utilized for interacting with ERC20 tokens.
  * @constant
  */
-export const IERC20 = new utils.Interface(require('../abi/IERC20.json'));
+export const IERC20 = new utils.Interface(IERC20ABI);
 
 /**
  * The ABI for the `IERC1271` interface, which is utilized for signature validation by contracts.
  * @constant
  */
-export const IERC1271 = new utils.Interface(require('../abi/IERC1271.json'));
+export const IERC1271 = new utils.Interface(IERC1271ABI);
 
 /**
  * The ABI for the `IL1Bridge` interface, which is utilized for transferring ERC20 tokens from L1 to L2.
  * @constant
  */
-export const L1_BRIDGE_ABI = new utils.Interface(
-  require('../abi/IL1Bridge.json')
-);
+export const L1_BRIDGE_ABI = new utils.Interface(IL1BridgeABI);
 
 /**
  * The ABI for the `IL2Bridge` interface, which is utilized for transferring ERC20 tokens from L2 to L1.
  * @constant
  */
-export const L2_BRIDGE_ABI = new utils.Interface(
-  require('../abi/IL2Bridge.json')
-);
+export const L2_BRIDGE_ABI = new utils.Interface(IL2BridgeABI);
 
 /**
  * The ABI for the `INonceHolder` interface, which is utilized for managing deployment nonces.
  * @constant
  */
-export const NONCE_HOLDER_ABI = new utils.Interface(
-  require('../abi/INonceHolder.json')
-);
+export const NONCE_HOLDER_ABI = new utils.Interface(INonceHolderABI);
 
 /**
  * The address of the L1 `ETH` token.

--- a/tests/integration/contract.test.ts
+++ b/tests/integration/contract.test.ts
@@ -5,6 +5,12 @@ import {ethers} from 'ethers';
 
 const {expect} = chai;
 
+import TokensL1 from '../tokens.json';
+import Token from '../files/Token.json';
+import Paymaster from '../files/Paymaster.json';
+import Storage from '../files/Storage.json';
+import Demo from '../files/Demo.json';
+
 describe('ContractFactory', () => {
   const PRIVATE_KEY =
     '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110';
@@ -12,26 +18,20 @@ describe('ContractFactory', () => {
   const provider = Provider.getDefaultProvider(types.Network.Localhost);
   const wallet = new Wallet(PRIVATE_KEY, provider);
 
-  const tokenPath = '../files/Token.json';
-  const paymasterPath = '../files/Paymaster.json';
-  const storagePath = '../files/Storage.json';
-  const demoPath = '../files/Demo.json';
-
-  const TOKENS_L1 = require('../tokens.json');
-  const DAI_L1 = TOKENS_L1[0].address;
+  const DAI_L1 = TokensL1[0].address;
 
   describe('#constructor()', () => {
     it('`ContractFactory(abi, bytecode, runner)` should return a `ContractFactory` with `create` deployment', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet);
 
       expect(factory.deploymentType).to.be.equal('create');
     });
 
     it("`ContractFactory(abi, bytecode, runner, 'createAccount')` should return a `ContractFactory` with `createAccount` deployment", async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(
         abi,
         bytecode,
@@ -43,16 +43,16 @@ describe('ContractFactory', () => {
     });
 
     it("`ContractFactory(abi, bytecode, runner, 'create2')` should return a `ContractFactory` with `create2` deployment", async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
 
       expect(factory.deploymentType).to.be.equal('create2');
     });
 
     it("`ContractFactory(abi, bytecode, runner, 'create2Account')` should return a `ContractFactory` with `create2Account` deployment", async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(
         abi,
         bytecode,
@@ -64,8 +64,8 @@ describe('ContractFactory', () => {
     });
 
     it("`ContractFactory(abi, bytecode, runner, '')` should throw an error when invalid deployment type is specified", async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       try {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
@@ -80,9 +80,8 @@ describe('ContractFactory', () => {
 
   describe('#deploy()', () => {
     it('should deploy a contract without constructor using CREATE opcode', async () => {
-      const abi = require(storagePath).contracts['Storage.sol:Storage'].abi;
-      const bytecode: string =
-        require(storagePath).contracts['Storage.sol:Storage'].bin;
+      const abi = Storage.contracts['Storage.sol:Storage'].abi;
+      const bytecode: string = Storage.contracts['Storage.sol:Storage'].bin;
       const factory = new ContractFactory(abi, bytecode, wallet);
       const contract = await factory.deploy();
 
@@ -91,8 +90,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy a contract with a constructor using CREATE opcode', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet);
       const contract = await factory.deploy('Ducat', 'Ducat', 18);
 
@@ -101,13 +100,13 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy a contract with dependencies using CREATE opcode', async () => {
-      const abi = require(demoPath).contracts['Demo.sol:Demo'].abi;
-      const bytecode: string = require(demoPath).contracts['Demo.sol:Demo'].bin;
+      const abi = Demo.contracts['Demo.sol:Demo'].abi;
+      const bytecode: string = Demo.contracts['Demo.sol:Demo'].bin;
 
       const factory = new ContractFactory(abi, bytecode, wallet);
       const contract = (await factory.deploy({
         customData: {
-          factoryDeps: [require(demoPath).contracts['Foo.sol:Foo'].bin],
+          factoryDeps: [Demo.contracts['Foo.sol:Foo'].bin],
         },
       })) as Contract;
 
@@ -116,8 +115,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy an account using CREATE opcode', async () => {
-      const paymasterAbi = require(paymasterPath).abi;
-      const paymasterBytecode = require(paymasterPath).bytecode;
+      const paymasterAbi = Paymaster.abi;
+      const paymasterBytecode = Paymaster.bytecode;
       const accountFactory = new ContractFactory(
         paymasterAbi,
         paymasterBytecode,
@@ -133,9 +132,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy a contract without a constructor using CREATE2 opcode', async () => {
-      const abi = require(storagePath).contracts['Storage.sol:Storage'].abi;
-      const bytecode: string =
-        require(storagePath).contracts['Storage.sol:Storage'].bin;
+      const abi = Storage.contracts['Storage.sol:Storage'].abi;
+      const bytecode: string = Storage.contracts['Storage.sol:Storage'].bin;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
       const contract = await factory.deploy({
         customData: {salt: ethers.utils.hexlify(ethers.utils.randomBytes(32))},
@@ -146,8 +144,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy a contract with a constructor using CREATE2 opcode', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
       const contract = await factory.deploy('Ducat', 'Ducat', 18, {
         customData: {salt: ethers.utils.hexlify(ethers.utils.randomBytes(32))},
@@ -160,14 +158,14 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy a contract with dependencies using CREATE2 opcode', async () => {
-      const abi = require(demoPath).contracts['Demo.sol:Demo'].abi;
-      const bytecode: string = require(demoPath).contracts['Demo.sol:Demo'].bin;
+      const abi = Demo.contracts['Demo.sol:Demo'].abi;
+      const bytecode: string = Demo.contracts['Demo.sol:Demo'].bin;
 
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
       const contract = (await factory.deploy({
         customData: {
           salt: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
-          factoryDeps: [require(demoPath).contracts['Foo.sol:Foo'].bin],
+          factoryDeps: [Demo.contracts['Foo.sol:Foo'].bin],
         },
       })) as Contract;
 
@@ -176,8 +174,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should deploy an account using CREATE2 opcode', async () => {
-      const paymasterAbi = require(paymasterPath).abi;
-      const paymasterBytecode = require(paymasterPath).bytecode;
+      const paymasterAbi = Paymaster.abi;
+      const paymasterBytecode = Paymaster.bytecode;
       const accountFactory = new ContractFactory(
         paymasterAbi,
         paymasterBytecode,
@@ -196,8 +194,8 @@ describe('ContractFactory', () => {
 
   describe('getDeployTransaction()', () => {
     it('should return a deployment transaction', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet);
 
       const result = factory.getDeployTransaction('Ducat', 'Ducat', 18);
@@ -205,8 +203,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should throw an error when salt is not provided in CRATE2 deployment', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
 
       try {
@@ -219,8 +217,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should throw an error when salt is not provided in hexadecimal format in CRATE2 deployment', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
 
       try {
@@ -233,8 +231,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should throw an error when invalid salt length is provided in CRATE2 deployment', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
 
       try {
@@ -247,8 +245,8 @@ describe('ContractFactory', () => {
     }).timeout(10_000);
 
     it('should throw an error when invalid factory deps are provided in CRATE2 deployment', async () => {
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
 
       try {

--- a/tests/integration/paymaster.test.ts
+++ b/tests/integration/paymaster.test.ts
@@ -5,6 +5,9 @@ import {Contract, ethers, BigNumber} from 'ethers';
 
 const {expect} = chai;
 
+import Token from '../files/Token.json';
+import Paymaster from '../files/Paymaster.json';
+
 describe('Paymaster', () => {
   const PRIVATE_KEY =
     '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110';
@@ -12,17 +15,14 @@ describe('Paymaster', () => {
   const provider = Provider.getDefaultProvider(types.Network.Localhost);
   const wallet = new Wallet(PRIVATE_KEY, provider);
 
-  const tokenPath = '../files/Token.json';
-  const paymasterPath = '../files/Paymaster.json';
-
   describe('#ApprovalBased', () => {
     it('use ERC20 token to pay transaction fee', async () => {
       const INIT_MINT_AMOUNT = 10;
       const MINT_AMOUNT = 3;
       const MINIMAL_ALLOWANCE = 1;
 
-      const abi = require(tokenPath).abi;
-      const bytecode: string = require(tokenPath).bytecode;
+      const abi = Token.abi;
+      const bytecode: string = Token.bytecode;
       const factory = new ContractFactory(abi, bytecode, wallet);
       const tokenContract = (await factory.deploy(
         'Ducat',
@@ -34,8 +34,8 @@ describe('Paymaster', () => {
       // mint tokens to wallet, so it could pay fee with tokens
       await tokenContract.mint(await wallet.getAddress(), INIT_MINT_AMOUNT);
 
-      const paymasterAbi = require(paymasterPath).abi;
-      const paymasterBytecode = require(paymasterPath).bytecode;
+      const paymasterAbi = Paymaster.abi;
+      const paymasterBytecode = Paymaster.bytecode;
       const accountFactory = new ContractFactory(
         paymasterAbi,
         paymasterBytecode,
@@ -64,7 +64,7 @@ describe('Paymaster', () => {
       const walletTokenBalanceBeforeTx = await wallet.getBalance(tokenAddress);
 
       // perform tx using paymaster
-      const tokenAbi = new ethers.utils.Interface(require(tokenPath).abi);
+      const tokenAbi = new ethers.utils.Interface(Token.abi);
       const tx = await wallet.sendTransaction({
         to: tokenAddress,
         data: tokenAbi.encodeFunctionData('mint', [

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -3,6 +3,8 @@ import '../custom-matchers';
 import {Provider, types, utils, Wallet} from '../../src';
 import {BigNumber, ethers} from 'ethers';
 
+import TokensL1 from '../tokens.json';
+
 describe('Provider', () => {
   const ADDRESS = '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049';
   const PRIVATE_KEY =
@@ -12,8 +14,7 @@ describe('Provider', () => {
   const provider = Provider.getDefaultProvider();
   const wallet = new Wallet(PRIVATE_KEY, provider);
 
-  const TOKENS_L1 = require('../tokens.json');
-  const DAI_L1 = TOKENS_L1[0].address;
+  const DAI_L1 = TokensL1[0].address;
 
   const TOKEN = '0x841c43Fa5d8fFfdB9efE3358906f7578d8700Dd4';
   const PAYMASTER = '0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174';

--- a/tests/integration/signer.test.ts
+++ b/tests/integration/signer.test.ts
@@ -3,6 +3,8 @@ import '../custom-matchers';
 import {Provider, utils, Wallet, L2VoidSigner, L1VoidSigner} from '../../src';
 import {ethers, BigNumber} from 'ethers';
 
+import TokensL1 from '../tokens.json';
+
 const {expect} = chai;
 
 describe('L2VoidSigner', () => {
@@ -305,8 +307,7 @@ describe('L1VoidSigner', () => {
   const ethProvider = ethers.getDefaultProvider('http://localhost:8545');
   const signer = new L1VoidSigner(ADDRESS, ethProvider, provider);
 
-  const TOKENS_L1 = require('../tokens.json');
-  const DAI_L1 = TOKENS_L1[0].address;
+  const DAI_L1 = TokensL1[0].address;
 
   describe('#constructor()', () => {
     it('`L1VoidSigner(privateKey, providerL1, providerL2)` should return a `L1VoidSigner` with L1 and L2 provider', async () => {

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -4,6 +4,8 @@ import {Provider, utils, Wallet} from '../../src';
 import {ethers, BigNumber} from 'ethers';
 import * as fs from 'fs';
 
+import TokensL1 from '../tokens.json';
+
 const {expect} = chai;
 
 describe('Wallet', () => {
@@ -18,8 +20,7 @@ describe('Wallet', () => {
   const ethProvider = ethers.getDefaultProvider('http://localhost:8545');
   const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
 
-  const TOKENS_L1 = require('../tokens.json');
-  const DAI_L1 = TOKENS_L1[0].address;
+  const DAI_L1 = TokensL1[0].address;
 
   const TOKEN = '0x841c43Fa5d8fFfdB9efE3358906f7578d8700Dd4';
   const PAYMASTER = '0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174';

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,6 +8,10 @@ import {
 } from '../src';
 import {ethers} from 'ethers';
 
+import TokensL1 from './tokens.json';
+import Token from './files/Token.json';
+import Paymaster from './files/Paymaster.json';
+
 const PRIVATE_KEY =
   '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110';
 
@@ -15,8 +19,6 @@ const provider = Provider.getDefaultProvider(types.Network.Localhost);
 const ethProvider = ethers.getDefaultProvider('http://127.0.0.1:8545');
 
 const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
-
-const TOKENS_L1 = require('./tokens.json');
 
 const SALT =
   '0x293328ad84b118194c65a0dc0defdb6483740d3163fd99b260907e15f2e2f642';
@@ -29,11 +31,8 @@ async function deployPaymasterAndToken(): Promise<{
   token: string;
   paymaster: string;
 }> {
-  const tokenPath = './files/Token.json';
-  const paymasterPath = './files/Paymaster.json';
-
-  const abi = require(tokenPath).abi;
-  const bytecode: string = require(tokenPath).bytecode;
+  const abi = Token.abi;
+  const bytecode: string = Token.bytecode;
   const factory = new ContractFactory(abi, bytecode, wallet, 'create2');
   const tokenContract = (await factory.deploy('Crown', 'Crown', 18, {
     customData: {salt: SALT},
@@ -44,8 +43,8 @@ async function deployPaymasterAndToken(): Promise<{
   const mintTx = await tokenContract.mint(wallet.address, 50);
   await mintTx.wait();
 
-  const paymasterAbi = require(paymasterPath).abi;
-  const paymasterBytecode = require(paymasterPath).bytecode;
+  const paymasterAbi = Paymaster.abi;
+  const paymasterBytecode = Paymaster.bytecode;
 
   const accountFactory = new ContractFactory(
     paymasterAbi,
@@ -100,7 +99,7 @@ Deploy token to the L2 network through deposit transaction.
  */
 async function main() {
   console.log('===== Depositing DAI to L2 =====');
-  const l2TokenAddress = await createTokenL2(TOKENS_L1[0].address);
+  const l2TokenAddress = await createTokenL2(TokensL1[0].address);
   console.log(`L2 DAI address: ${l2TokenAddress}`);
 
   console.log('===== Deploying token and paymaster =====');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
 
     "esModuleInterop": true,
     "declaration": true,
+    "resolveJsonModule": true,
 
     "preserveSymlinks": true,
     "preserveWatchOutput": true,


### PR DESCRIPTION
# What :computer: 
* Ethers V5:  Replace `require` with `import`.

# Why :hand:
* It's best practice to use ECMAScript standard since TypeScript is configured to build to ES2019.