### PR TITLE
Ethers V5: Fix `applyL1ToL2Alias` and `undoL1ToL2Alias` to always return 20 bytes long address

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -111,7 +111,7 @@ export class EIP712Signer {
   }
 
   /**
-   * Signs a transaction request using EIP712
+   * Signs a transaction request using EIP712.
    *
    * @param transaction The transaction request that needs to be signed.
    * @returns A promise that resolves to the signature of the transaction.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -827,10 +827,12 @@ const ADDRESS_MODULO = BigNumber.from(2).pow(160);
  *
  */
 export function applyL1ToL2Alias(address: string): string {
-  return ethers.utils.hexlify(
+  return ethers.utils.hexZeroPad(
     ethers.BigNumber.from(address)
       .add(L1_TO_L2_ALIAS_OFFSET)
       .mod(ADDRESS_MODULO)
+      .toHexString(),
+    20
   );
 }
 
@@ -854,7 +856,7 @@ export function undoL1ToL2Alias(address: string): string {
     result = result.add(ADDRESS_MODULO);
   }
 
-  return ethers.utils.hexlify(result);
+  return ethers.utils.hexZeroPad(result.toHexString(), 20);
 }
 
 /**

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -803,9 +803,8 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
    * const tokenWithdrawHandle = await wallet.withdraw({
-   *   token: tokenL2,
+   *   token: utils.ETH_ADDRESS,
    *   amount: 10_000_000,
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
@@ -832,6 +831,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * @example Transfer ETH
    *
    * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    *
@@ -840,7 +840,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * const transferHandle = await wallet.transfer({
    *   to: Wallet.createRandom().address,
-   *   amount: ethers.parseEther("0.01"),
+   *   amount: ethers.utils.parseEther("0.01"),
    * });
    *
    * const tx = await transferHandle.wait();
@@ -850,6 +850,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token
    *
    * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
@@ -860,7 +861,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * const transferHandle = await wallet.transfer({
    *   to: Wallet.createRandom().address,
-   *   amount: ethers.parseEther("0.01"),
+   *   amount: ethers.utils.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
    *     token: token,
@@ -1048,6 +1049,12 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
   /**
    * Static methods to create Wallet instances.
    * @param options  Additional options.
+   *
+   * @example
+   *
+   * import { Wallet} from "zksync-ethers";
+   *
+   * const wallet = Wallet.createRandom();
    */
   static override createRandom(options?: any): Wallet {
     const wallet = super.createRandom(options);
@@ -1062,7 +1069,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -56,6 +56,14 @@ describe('utils', () => {
         '0x813A42B8205E5DedCd3374e5f4419843ADa77FFC'.toLowerCase()
       );
     });
+
+    it('should return the L2 contract address by padding zero to left', async () => {
+      const l1ContractAddress = '0xeeeeffffffffffffffffffffffffffffffffeeef';
+      const l2ContractAddress = utils.applyL1ToL2Alias(l1ContractAddress);
+      expect(l2ContractAddress.toLowerCase()).to.be.equal(
+        '0x0000000000000000000000000000000000000000'.toLowerCase()
+      );
+    });
   });
 
   describe('#undoL1ToL2Alias()', () => {
@@ -64,6 +72,14 @@ describe('utils', () => {
       const l1ContractAddress = utils.undoL1ToL2Alias(l2ContractAddress);
       expect(l1ContractAddress.toLowerCase()).to.be.equal(
         '0x702942B8205E5dEdCD3374E5f4419843adA76Eeb'.toLowerCase()
+      );
+    });
+
+    it('should return the L1 contract address by padding zero to left', async () => {
+      const l2ContractAddress = '0x1111000000000000000000000000000000001111';
+      const l1ContractAddress = utils.undoL1ToL2Alias(l2ContractAddress);
+      expect(l1ContractAddress.toLowerCase()).to.be.equal(
+        '0x0000000000000000000000000000000000000000'.toLowerCase()
       );
     });
 


### PR DESCRIPTION
# What :computer: 
* Fix `applyL1ToL2Alias` and `undoL1ToL2Alias` to always return 20 bytes long address by padding zeros to left.