### PR TITLE
Ethers Vg: Fix `applyL1ToL2Alias` and `undoL1ToL2Alias` to always return 20 bytes long address

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -115,7 +115,7 @@ export class EIP712Signer {
   }
 
   /**
-   * Signs a transaction request using EIP712
+   * Signs a transaction request using EIP712.
    *
    * @param transaction The transaction request that needs to be signed.
    * @returns A promise that resolves to the signature of the transaction.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,10 +14,6 @@ import {
 import {Provider} from './provider';
 import {EIP712Signer} from './signer';
 import {IERC20__factory, IL1Bridge__factory} from './typechain';
-
-export * from './paymaster-utils';
-export {EIP712_TYPES} from './signer';
-
 import IZkSyncABI from './abi/IZkSync.json';
 import IContractDeployerABI from './abi/IContractDeployer.json';
 import IL1MessengerABI from './abi/IL1Messenger.json';
@@ -26,6 +22,9 @@ import IERC1271ABI from './abi/IERC1271.json';
 import IL1BridgeABI from './abi/IL1Bridge.json';
 import IL2BridgeABI from './abi/IL2Bridge.json';
 import INonceHolderABI from './abi/INonceHolder.json';
+
+export * from './paymaster-utils';
+export {EIP712_TYPES} from './signer';
 
 /**
  * The ABI for the `ZkSync` interface.
@@ -797,10 +796,11 @@ const ADDRESS_MODULO = 2n ** 160n;
  *
  */
 export function applyL1ToL2Alias(address: string): string {
-  return ethers.hexlify(
+  return ethers.zeroPadValue(
     ethers.toBeHex(
       (BigInt(address) + BigInt(L1_TO_L2_ALIAS_OFFSET)) % ADDRESS_MODULO
-    )
+    ),
+    20
   );
 }
 
@@ -823,7 +823,7 @@ export function undoL1ToL2Alias(address: string): string {
   if (result < 0n) {
     result += ADDRESS_MODULO;
   }
-  return ethers.hexlify(ethers.toBeHex(result));
+  return ethers.zeroPadValue(ethers.toBeHex(result), 20);
 }
 
 /**

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -785,7 +785,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
    * const tokenWithdrawHandle = await wallet.withdraw({
-   *   token: tokenL2,
+   *   token: utils.ETH_ADDRESS,
    *   amount: 10_000_000,
    * });
    *
@@ -800,9 +800,8 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
    * const tokenWithdrawHandle = await wallet.withdraw({
-   *   token: tokenL2,
+   *   token: utils.ETH_ADDRESS,
    *   amount: 10_000_000,
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
@@ -828,7 +827,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example Transfer ETH
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types } from "zksync-ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    *
@@ -846,7 +845,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types } from "zksync-ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
@@ -1022,7 +1021,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -56,6 +56,14 @@ describe('utils', () => {
         '0x813A42B8205E5DedCd3374e5f4419843ADa77FFC'.toLowerCase()
       );
     });
+
+    it('should return the L2 contract address by padding zero to left', async () => {
+      const l1ContractAddress = '0xeeeeffffffffffffffffffffffffffffffffeeef';
+      const l2ContractAddress = utils.applyL1ToL2Alias(l1ContractAddress);
+      expect(l2ContractAddress.toLowerCase()).to.be.equal(
+        '0x0000000000000000000000000000000000000000'.toLowerCase()
+      );
+    });
   });
 
   describe('#undoL1ToL2Alias()', () => {
@@ -64,6 +72,14 @@ describe('utils', () => {
       const l1ContractAddress = utils.undoL1ToL2Alias(l2ContractAddress);
       expect(l1ContractAddress.toLowerCase()).to.be.equal(
         '0x702942B8205E5dEdCD3374E5f4419843adA76Eeb'.toLowerCase()
+      );
+    });
+
+    it('should return the L1 contract address by padding zero to left', async () => {
+      const l2ContractAddress = '0x1111000000000000000000000000000000001111';
+      const l1ContractAddress = utils.undoL1ToL2Alias(l2ContractAddress);
+      expect(l1ContractAddress.toLowerCase()).to.be.equal(
+        '0x0000000000000000000000000000000000000000'.toLowerCase()
       );
     });
 


### PR DESCRIPTION
# What :computer: 
* Fix `applyL1ToL2Alias` and `undoL1ToL2Alias` to always return 20 bytes long address by padding zeros to left.