### PR TITLE
Ethers V6: Create prefetched txs correctly in `Block` object

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -106,20 +106,13 @@ export function JsonRpcApiProvider<
       return new Log(formatLog(value), this);
     }
 
-    override _wrapBlock(value: any, network: ethers.Network): Block {
-      const block: any = formatBlock(value);
-      return new Block(super._wrapBlock(block, network), this);
+    override _wrapBlock(value: any): Block {
+      return new Block(formatBlock(value), this);
     }
 
-    override _wrapTransactionResponse(
-      value: any,
-      network: ethers.Network
-    ): TransactionResponse {
+    override _wrapTransactionResponse(value: any): TransactionResponse {
       const tx: any = formatTransactionResponse(value);
-      return new TransactionResponse(
-        super._wrapTransactionResponse(tx, network),
-        this
-      );
+      return new TransactionResponse(tx, this);
     }
 
     override _wrapTransactionReceipt(value: any): TransactionReceipt {
@@ -800,7 +793,7 @@ export function JsonRpcApiProvider<
     override async broadcastTransaction(
       signedTx: string
     ): Promise<TransactionResponse> {
-      const {blockNumber, hash, network} = await resolveProperties({
+      const {blockNumber, hash} = await resolveProperties({
         blockNumber: this.getBlockNumber(),
         hash: this._perform({
           method: 'broadcastTransaction',
@@ -814,10 +807,9 @@ export function JsonRpcApiProvider<
         throw new Error('@TODO: the returned hash did not match!');
       }
 
-      return this._wrapTransactionResponse(
-        <any>tx,
-        network
-      ).replaceableTransaction(blockNumber);
+      return this._wrapTransactionResponse(<any>tx).replaceableTransaction(
+        blockNumber
+      );
     }
 
     /**

--- a/tests/integration/format.test.ts
+++ b/tests/integration/format.test.ts
@@ -22,10 +22,7 @@ describe('format', () => {
         nonce: 0n,
         data: '0x',
       };
-      const result = provider._wrapTransactionResponse(
-        value,
-        await provider.getNetwork()
-      );
+      const result = provider._wrapTransactionResponse(value);
       expect(result.to).to.be.equal(ethers.ZeroAddress);
     });
 
@@ -40,10 +37,7 @@ describe('format', () => {
         data: '0x',
         creates: null,
       };
-      const result = provider._wrapTransactionResponse(
-        value,
-        await provider.getNetwork()
-      );
+      const result = provider._wrapTransactionResponse(value);
       expect(result.to).to.be.null;
     });
 
@@ -59,10 +53,7 @@ describe('format', () => {
         data: '0x',
         accessList: null,
       };
-      const result = provider._wrapTransactionResponse(
-        value,
-        await provider.getNetwork()
-      );
+      const result = provider._wrapTransactionResponse(value);
       expect(result.accessList).to.has.lengthOf(0);
     });
 
@@ -77,16 +68,13 @@ describe('format', () => {
         nonce: 0n,
         data: '0x',
       };
-      const result = provider._wrapTransactionResponse(
-        value,
-        await provider.getNetwork()
-      );
+      const result = provider._wrapTransactionResponse(value);
       expect(result.blockHash).to.be.null;
     });
 
     it('should thrown an error when hash is not provided', async () => {
       try {
-        provider._wrapTransactionResponse({}, await provider.getNetwork());
+        provider._wrapTransactionResponse({});
       } catch (e) {
         expect((e as Error).message).to.include('invalid value for value.hash');
       }

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -304,9 +304,19 @@ describe('Provider', () => {
   });
 
   describe('#getBlock()', () => {
-    it('should return a block with transactions', async () => {
-      const result = await provider.getBlock('latest', true);
+    it('should return a block', async () => {
+      const blockNumber = (await provider.getBlockNumber()) - 1;
+      const result = await provider.getBlock(blockNumber, false);
       expect(result).not.to.be.null;
+      expect(result.transactions).not.to.be.empty;
+    });
+
+    it('should return a block with prefetch transactions', async () => {
+      const blockNumber = (await provider.getBlockNumber()) - 1;
+      const result = await provider.getBlock(blockNumber, true);
+      expect(result).not.to.be.null;
+      expect(result.transactions).not.to.be.empty;
+      expect(result.prefetchedTransactions).not.to.be.empty;
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@adraffy/ens-normalize@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
-  integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
+"@adraffy/ens-normalize@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
+  integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
 "@babel/code-frame@^7.0.0":
   version "7.23.5"
@@ -918,12 +918,12 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^6.7.1:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.10.0.tgz#20f3c63c60d59a993f8090ad423d8a3854b3b1cd"
-  integrity sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==
+ethers@^6.11.1:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.11.1.tgz#96aae00b627c2e35f9b0a4d65c7ab658259ee6af"
+  integrity sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==
   dependencies:
-    "@adraffy/ens-normalize" "1.10.0"
+    "@adraffy/ens-normalize" "1.10.1"
     "@noble/curves" "1.2.0"
     "@noble/hashes" "1.3.2"
     "@types/node" "18.15.13"


### PR DESCRIPTION
# What :computer: 
* Prefetched transactions were not created correctly in `Block` object. This PR solves this issue.