### PR TITLE
Ethers V6: Add support for Era Test Node and disable caching for local networks

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1801,6 +1801,8 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
         return new Provider('https://sepolia.era.zksync.dev');
       case ZkSyncNetwork.Mainnet:
         return new Provider('https://mainnet.era.zksync.io');
+      case ZkSyncNetwork.EraTestNode:
+        return new Provider('http://localhost:8011');
       default:
         return new Provider('http://localhost:3050');
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -987,6 +987,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
 
   /**
    * Creates a new `Provider` instance for connecting to an L2 network.
+   * Caching is disabled for local networks.
    * @param [url] The network RPC URL. Defaults to the local network.
    * @param [network] The network name, chain ID, or object with network details.
    * @param [options] Additional options for the provider.
@@ -999,7 +1000,17 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
     if (!url) {
       url = 'http://localhost:3050';
     }
-    super(url, network, options);
+
+    const isLocalNetwork =
+      typeof url === 'string'
+        ? url.includes('localhost') || url.includes('127.0.0.1')
+        : url.url.includes('localhost') || url.url.includes('127.0.0.1');
+
+    const optionsWithDisabledCache = isLocalNetwork
+      ? {...options, cacheTimeout: -1}
+      : options;
+
+    super(url, network, optionsWithDisabledCache);
     typeof url === 'string'
       ? (this.#connect = new FetchRequest(url))
       : (this.#connect = url.clone());

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export enum Network {
   Goerli = 5,
   Sepolia = 6,
   Localhost = 9,
+  EraTestNode = 10,
 }
 
 /** Enumerated list of priority queue types. */


### PR DESCRIPTION
# What :computer: 
* Add support for Era Test Node.
* Disable caching for local networks.