### PR TITLE
Ethers V6: remove support for the `ZKSYNC_WEB3_API_URL` environment variable

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1794,15 +1794,11 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
 
   /**
    * Creates a new `Provider` from provided URL or network name.
-   * The URL can be configured using `ZKSYNC_WEB3_API_URL` environment variable.
    * @param zksyncNetwork The type of zkSync network.
    */
   static getDefaultProvider(
     zksyncNetwork: ZkSyncNetwork = ZkSyncNetwork.Localhost
   ): Provider {
-    if (process.env.ZKSYNC_WEB3_API_URL) {
-      return new Provider(process.env.ZKSYNC_WEB3_API_URL);
-    }
     switch (zksyncNetwork) {
       case ZkSyncNetwork.Localhost:
         return new Provider('http://localhost:3050');

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,7 +918,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^6.11.1:
+ethers@^6.7.1:
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.11.1.tgz#96aae00b627c2e35f9b0a4d65c7ab658259ee6af"
   integrity sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==


### PR DESCRIPTION
# What :computer: 
* Remove the support for the `ZKSYNC_WEB3_API_URL` in `Provider.getDefaultProvider`.

# Why :hand:
* Getting environment variable using `process.env` is only available on `Node.js` and it's not compatible with browsers.