### PR TITLE
Ethers V5: Remove support for the `ZKSYNC_WEB3_API_URL` environment variable

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1405,15 +1405,12 @@ export class Provider extends ethers.providers.JsonRpcProvider {
 
   /**
    * Creates a new `Provider` from provided URL or network name.
-   * The URL can be configured using `ZKSYNC_WEB3_API_URL` environment variable.
+   *
    * @param zksyncNetwork The type of zkSync network.
    */
   static getDefaultProvider(
     zksyncNetwork: ZkSyncNetwork = ZkSyncNetwork.Localhost
   ): Provider {
-    if (process.env.ZKSYNC_WEB3_API_URL) {
-      return new Provider(process.env.ZKSYNC_WEB3_API_URL);
-    }
     switch (zksyncNetwork) {
       case ZkSyncNetwork.Localhost:
         return new Provider('http://localhost:3050');


### PR DESCRIPTION
# What :computer: 
* Remove the support for the `ZKSYNC_WEB3_API_URL` in `Provider.getDefaultProvider`.

# Why :hand:
* Getting environment variable using `process.env` is only available on `Node.js` and it's not compatible with browsers.