### PR TITLE
Ethers V5: Add support for era test node

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1420,6 +1420,8 @@ export class Provider extends ethers.providers.JsonRpcProvider {
         return new Provider('https://sepolia.era.zksync.dev');
       case ZkSyncNetwork.Mainnet:
         return new Provider('https://mainnet.era.zksync.io');
+      case ZkSyncNetwork.EraTestNode:
+        return new Provider('http://localhost:8011');
       default:
         return new Provider('http://localhost:3050');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export enum Network {
   Goerli = 5,
   Sepolia = 6,
   Localhost = 9,
+  EraTestNode = 10,
 }
 
 /** Enumerated list of priority queue types. */


### PR DESCRIPTION
# What :computer: 
* Add support for era test node.