### PR TITLE
increase default gas per pubdata

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,8 +196,8 @@ export const L1_RECOMMENDED_MIN_ETH_DEPOSIT_GAS_LIMIT = 200_000;
  *
  * @constant
  */
-// It is a realistic value, but it is large enough to fill into any batch regardless of the pubdata price.
-export const DEFAULT_GAS_PER_PUBDATA_LIMIT = 50_000;
+// It is a large value to fill into any batch regardless of the pubdata price.
+export const DEFAULT_GAS_PER_PUBDATA_LIMIT = 4_294_967_295;
 
 /**
  * The `L1->L2` transactions are required to have the following gas per pubdata byte.


### PR DESCRIPTION
# What :computer: 

- Default gas per pubdata signed increased to 2^32 - 1

# Why :hand:

- To support broader range of gas per pubdata supported by the future protocol versions

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
