### PR TITLE
Ethers V6: Drop support for the `Goerli` network

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1381,7 +1381,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    *
    * const testnetPaymasterBytecodeHash = "0x010000f16d2b10ddeb1c32f2c9d222eb1aea0f638ec94a81d4e916c627720e30";
    *
-   * const provider = Provider.getDefaultProvider(types.Network.Goerli);
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * console.log(`Bytecode: ${await provider.getBytecodeByHash(testnetPaymasterBytecodeHash)}`);
    */
   override async getBytecodeByHash(
@@ -1397,7 +1397,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    *
    * import { Provider, types, utils } from "zksync-ethers";
    *
-   * const provider = Provider.getDefaultProvider(types.Network.Goerli);
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * console.log(`Raw block transactions: ${utils.toJSON(await provider.getRawBlockTransactions(90_000))}`);
    */
   override async getRawBlockTransactions(
@@ -1803,8 +1803,6 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
     switch (zksyncNetwork) {
       case ZkSyncNetwork.Localhost:
         return new Provider('http://localhost:3050');
-      case ZkSyncNetwork.Goerli:
-        return new Provider('https://zksync2-testnet.zksync.dev');
       case ZkSyncNetwork.Sepolia:
         return new Provider('https://sepolia.era.zksync.dev');
       case ZkSyncNetwork.Mainnet:

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -52,12 +52,6 @@ describe('Provider', () => {
       expect(network.chainId).to.be.equal(270n);
     });
 
-    it('should return a provider connected to Goerli network', async () => {
-      const provider = Provider.getDefaultProvider(types.Network.Goerli);
-      const network = await provider.getNetwork();
-      expect(network.chainId).to.be.equal(280n);
-    });
-
     it('should return a provider connected to Sepolia network', async () => {
       const provider = Provider.getDefaultProvider(types.Network.Sepolia);
       const network = await provider.getNetwork();


### PR DESCRIPTION
# What :computer: 
* Drop support for the `Goerli` network.