### PR TITLE
Ethers V5: Drop support for `Goerli` network and fix typing

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1033,7 +1033,7 @@ export class Provider extends ethers.providers.JsonRpcProvider {
    *
    * const testnetPaymasterBytecodeHash = "0x010000f16d2b10ddeb1c32f2c9d222eb1aea0f638ec94a81d4e916c627720e30";
    *
-   * const provider = Provider.getDefaultProvider(types.Network.Goerli);
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * console.log(`Bytecode: ${await provider.getBytecodeByHash(testnetPaymasterBytecodeHash)}`);
    */
   async getBytecodeByHash(bytecodeHash: BytesLike): Promise<Uint8Array> {
@@ -1051,7 +1051,7 @@ export class Provider extends ethers.providers.JsonRpcProvider {
    *
    * import { Provider, types, utils } from "zksync-ethers";
    *
-   * const provider = Provider.getDefaultProvider(types.Network.Goerli);
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * console.log(`Raw block transactions: ${utils.toJSON(await provider.getRawBlockTransactions(90_000))}`);
    */
   async getRawBlockTransactions(
@@ -1416,8 +1416,6 @@ export class Provider extends ethers.providers.JsonRpcProvider {
     switch (zksyncNetwork) {
       case ZkSyncNetwork.Localhost:
         return new Provider('http://localhost:3050');
-      case ZkSyncNetwork.Goerli:
-        return new Provider('https://zksync2-testnet.zksync.dev');
       case ZkSyncNetwork.Sepolia:
         return new Provider('https://sepolia.era.zksync.dev');
       case ZkSyncNetwork.Mainnet:

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,7 @@ export interface TransactionResponse extends providers.TransactionResponse {
   /** The transaction index within the batch on the L1 network. */
   l1BatchTxIndex: number;
   /** Waits for transaction to be mined. */
-  wait(confirmations?: number): Promise<TransactionReceipt>
+  wait(confirmations?: number): Promise<TransactionReceipt>;
   /** Waits for transaction to be finalized. */
   waitFinalize(): Promise<TransactionReceipt>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,8 @@ export interface TransactionResponse extends providers.TransactionResponse {
   l1BatchNumber: number;
   /** The transaction index within the batch on the L1 network. */
   l1BatchTxIndex: number;
+  /** Waits for transaction to be mined. */
+  wait(confirmations?: number): Promise<TransactionReceipt>
   /** Waits for transaction to be finalized. */
   waitFinalize(): Promise<TransactionReceipt>;
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1202,7 +1202,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * await tx.wait();
    */
   override async sendTransaction(
-    transaction: ethers.providers.TransactionRequest
+    transaction: TransactionRequest
   ): Promise<TransactionResponse> {
     return (await super.sendTransaction(transaction)) as TransactionResponse;
   }

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -134,7 +134,9 @@ describe('Provider', () => {
 
   describe('#getTransactionDetails()', () => {
     it('should return transaction details', async () => {
-      const result = await provider.getTransactionDetails(receipt.transactionHash);
+      const result = await provider.getTransactionDetails(
+        receipt.transactionHash
+      );
       expect(result).not.to.be.null;
     });
   });
@@ -195,7 +197,9 @@ describe('Provider', () => {
 
   describe('#getTransactionStatus()', () => {
     it('should return transaction status', async () => {
-      const result = await provider.getTransactionStatus(receipt.transactionHash);
+      const result = await provider.getTransactionStatus(
+        receipt.transactionHash
+      );
       expect(result).not.to.be.null;
     });
 
@@ -496,7 +500,9 @@ describe('Provider', () => {
           amount: 5,
         });
       } catch (e) {
-        expect((e as Error).message).to.be.equal('Withdrawal target address is undefined!');
+        expect((e as Error).message).to.be.equal(
+          'Withdrawal target address is undefined!'
+        );
       }
     });
 

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -52,12 +52,6 @@ describe('Provider', () => {
       expect(network.chainId).to.be.equal(270);
     });
 
-    it('should return a provider connected to Goerli network', async () => {
-      const provider = Provider.getDefaultProvider(types.Network.Goerli);
-      const network = await provider.getNetwork();
-      expect(network.chainId).to.be.equal(280);
-    });
-
     it('should return a provider connected to Sepolia network', async () => {
       const provider = Provider.getDefaultProvider(types.Network.Sepolia);
       const network = await provider.getNetwork();

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -19,16 +19,16 @@ describe('Provider', () => {
   const TOKEN = '0x841c43Fa5d8fFfdB9efE3358906f7578d8700Dd4';
   const PAYMASTER = '0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174';
 
-  let tx: types.TransactionResponse;
+  let receipt: types.TransactionReceipt;
 
   before('setup', async function () {
     this.timeout(25_000);
-    tx = await wallet.transfer({
+    const tx = await wallet.transfer({
       token: utils.ETH_ADDRESS,
       to: RECEIVER,
       amount: 1_000_000,
     });
-    await tx.wait();
+    receipt = await tx.wait();
   });
 
   describe('#constructor()', () => {
@@ -140,7 +140,7 @@ describe('Provider', () => {
 
   describe('#getTransactionDetails()', () => {
     it('should return transaction details', async () => {
-      const result = await provider.getTransactionDetails(tx.hash);
+      const result = await provider.getTransactionDetails(receipt.transactionHash);
       expect(result).not.to.be.null;
     });
   });
@@ -201,7 +201,7 @@ describe('Provider', () => {
 
   describe('#getTransactionStatus()', () => {
     it('should return transaction status', async () => {
-      const result = await provider.getTransactionStatus(tx.hash);
+      const result = await provider.getTransactionStatus(receipt.transactionHash);
       expect(result).not.to.be.null;
     });
 
@@ -215,14 +215,14 @@ describe('Provider', () => {
 
   describe('#getTransaction()', () => {
     it('should return transaction', async () => {
-      const result = await provider.getTransaction(tx.hash);
+      const result = await provider.getTransaction(receipt.transactionHash);
       expect(result).not.to.be.null;
     });
   });
 
   describe('#getTransactionReceipt()', () => {
     it('should return transaction receipt', async () => {
-      const result = await provider.getTransaction(tx.hash);
+      const result = await provider.getTransaction(receipt.transactionHash);
       expect(result).not.to.be.null;
     });
   });
@@ -502,7 +502,7 @@ describe('Provider', () => {
           amount: 5,
         });
       } catch (e) {
-        expect(e).not.to.be.equal('withdrawal target address is undefined');
+        expect((e as Error).message).to.be.equal('Withdrawal target address is undefined!');
       }
     });
 
@@ -516,8 +516,8 @@ describe('Provider', () => {
           overrides: {value: 7},
         });
       } catch (e) {
-        expect(e).not.to.be.equal(
-          'The tx.value is not equal to the value withdrawn'
+        expect((e as Error).message).to.be.equal(
+          'The tx.value is not equal to the value withdrawn!'
         );
       }
     });


### PR DESCRIPTION
# What :computer: 
* Drop support for `Goerli` network.
* Fix typing for `TransactionResponse.wait()` and `Wallet.sendTransaction()` methods.