### PR TITLE
Ethers V5: Remove Goerli

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -714,8 +714,6 @@ export class Provider extends ethers.providers.JsonRpcProvider {
         switch (zksyncNetwork) {
             case ZkSyncNetwork.Localhost:
                 return new Provider("http://localhost:3050");
-            case ZkSyncNetwork.Goerli:
-                return new Provider("https://zksync2-testnet.zksync.dev");
             case ZkSyncNetwork.Sepolia:
                 return new Provider("https://sepolia.era.zksync.dev");
             case ZkSyncNetwork.Mainnet:

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,6 @@ export enum Network {
     Mainnet = 1,
     Ropsten = 3,
     Rinkeby = 4,
-    Goerli = 5,
     Sepolia = 6,
     Localhost = 9,
 }

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -42,12 +42,6 @@ describe("Provider", () => {
             expect(network.chainId).not.to.be.null;
         });
 
-        it("should return a provider connected to Goerli network", async () => {
-            const provider = Provider.getDefaultProvider(types.Network.Goerli);
-            const network = await provider.getNetwork();
-            expect(network.chainId).to.be.equal(280);
-        });
-
         it("should return a provider connected to Sepolia network", async () => {
             const provider = Provider.getDefaultProvider(types.Network.Sepolia);
             const network = await provider.getNetwork();


### PR DESCRIPTION
# What :computer: 
* Remove goerli from SDK 

# Why :hand:
* Goerli support has been deprecated both by Ethereum and by ZkSync
