### PR TITLE
Ethers V6: Add `contracts` namespace which exports typechain

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * as utils from './utils';
 export * as types from './types';
+export * as contracts from './typechain';
 export {
   EIP712Signer,
   Signer,


### PR DESCRIPTION
# What :computer: 
* Exports typechain as `contracts` namespace in order to provider easier interaction with common contracts.