### PR TITLE
Ethers V5: Add support for `zks` RPC methods in `Signer`

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -167,13 +167,14 @@ export class EIP712Signer {
 export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
   public override provider!: Provider;
   public eip712!: EIP712Signer;
+  protected providerL2?: Provider;
 
   override _signerL2() {
     return this;
   }
 
   override _providerL2() {
-    return this.provider;
+    return this.providerL2!;
   }
 
   /**
@@ -373,6 +374,8 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    * Creates a new Singer with provided `signer`.
    *
    * @param signer  The signer from browser wallet.
+   * @param [zksyncProvider] The provider instance for connecting to a L2 network. If not provided,
+   * the methods from the `zks` namespace are not supported, and interaction with them will result in an error.
    *
    * @example
    *
@@ -383,10 +386,12 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    * const signer = Signer.from(provider.getSigner() as any);
    */
   static from(
-    signer: ethers.providers.JsonRpcSigner & {provider: Provider}
+    signer: ethers.providers.JsonRpcSigner & {provider: Provider},
+    zksyncProvider?: Provider
   ): Signer {
     const newSigner: Signer = Object.setPrototypeOf(signer, Signer.prototype);
     newSigner.eip712 = new EIP712Signer(newSigner, newSigner.getChainId());
+    newSigner.providerL2 = zksyncProvider;
     return newSigner;
   }
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -182,21 +182,25 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example Get ETH balance
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * console.log(`ETH balance: ${await signer.getBalance()}`);
    *
    * @example Get token balance
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * const token = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
    *
@@ -214,11 +218,13 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * const allBalances = await signer.getAllBalances();
    */
@@ -231,11 +237,13 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * console.log(`Nonce: ${await signer.getDeploymentNonce()}`);
    */
@@ -248,11 +256,13 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * const l2BridgeContracts = await signer.getL2BridgeContracts();
    */
@@ -268,31 +278,35 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example Withdraw ETH
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
-   * const tokenWithdrawHandle = await signer.withdraw({
+   * await signer.withdraw({
    *   token: tokenL2,
    *   amount: 10_000_000,
    * });
    *
    * @example Withdraw ETH using paymaster to facilitate fee payment with an ERC20 token.
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
    * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
    * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
-   * const tokenWithdrawHandle = await wallet.withdraw({
+   * await wallet.withdraw({
    *   token: tokenL2,
    *   amount: 10_000_000,
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
@@ -319,35 +333,41 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example Transfer ETH
    *
-   * import { Web3Provider } from "zksync-ethers";
+   * import { Web3Provider, Provider, Wallet, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
-   * const transferHandle = signer.transfer({
+   * const tx = signer.transfer({
    *   to: Wallet.createRandom().address,
-   *   amount: ethers.parseEther("0.01"),
+   *   amount: ethers.utils.parseEther("0.01"),
    * });
    *
-   * const tx = await transferHandle.wait();
+   * const receipt = await tx.wait();
    *
-   * console.log(`The sum of ${tx.value} ETH was transferred to ${tx.to}`);
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
    *
    * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token
    *
-   * import { Web3Provider } from "zksync-ethers";
+   * import { Web3Provider, Provider, Wallet, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
    * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
-   * const transferHandle = signer.transfer({
+   * const tx = signer.transfer({
    *   to: Wallet.createRandom().address,
-   *   amount: ethers.parseEther("0.01"),
+   *   amount: ethers.utils.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
    *     token: token,
@@ -356,9 +376,9 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *   }),
    * });
    *
-   * const tx = await transferHandle.wait();
+   * const receipt = await tx.wait();
    *
-   * console.log(`The sum of ${tx.value} ETH was transferred to ${tx.to}`);
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
    */
   override async transfer(transaction: {
     to: Address;
@@ -379,11 +399,13 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const signer = Signer.from(provider.getSigner() as any);
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    */
   static from(
     signer: ethers.providers.JsonRpcSigner & {provider: Provider},
@@ -402,11 +424,13 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    *
    * @example
    *
-   * import { Web3Provider } from "zksync-ethers";
-   * import { ethers } from "ethers";
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
    *
-   * const provider = new Web3Provider(window.ethereum);
-   * const signer = provider.getSigner();
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
    *
    * const nonce = await signer.getNonce();
    */
@@ -420,6 +444,21 @@ export class Signer extends AdapterL2(ethers.providers.JsonRpcSigner) {
    * @param transaction The transaction request that needs to be broadcast to the network.
    *
    * @throws {Error} If `transaction.from` is mismatched from the private key.
+   *
+   * @example
+   *
+   * import { Web3Provider, Provider, types } from "zksync-ethers";
+   *
+   * const browserProvider = new Web3Provider(window.ethereum);
+   * const signer = Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia);
+   * );
+   *
+   * await signer.sendTransaction({
+   *     to: Wallet.createRandom().address,
+   *     value: 10_000_000
+   * });
    */
   override async sendTransaction(
     transaction: TransactionRequest
@@ -483,9 +522,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const mainContract = await signer.getMainContract();
    * console.log(mainContract.address);
@@ -502,9 +543,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const l1BridgeContracts = await signer.getL1BridgeContracts();
    */
@@ -523,9 +566,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
    *
@@ -550,9 +595,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x5C221E77624690fff6dd741493D735a17716c26B";
    * console.log(`Token allowance: ${await signer.getAllowanceL1(tokenL1)}`);
@@ -573,9 +620,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x5C221E77624690fff6dd741493D735a17716c26B";
    *
@@ -593,11 +642,14 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
-   * console.log(`Base cost: ${await signer.getBaseCost({ gasLimit: 100_000 })}`);
+   * const tokenL1 = "0x5C221E77624690fff6dd741493D735a17716c26B";
+   * await signer.approveERC20(tokenL1, 5);
    */
   override async approveERC20(
     token: Address,
@@ -617,9 +669,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * console.log(`Base cost: ${await signer.getBaseCost({ gasLimit: 100_000 })}`);
    */
@@ -634,34 +688,39 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
   /**
    * @inheritDoc
    *
-   * @example
+   * @example Deposit ETH
    *
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
+   *
+   * await signer.deposit({
+   *   token: utils.ETH_ADDRESS,
+   *   amount: 10_000_000,
+   * });
+   *
+   * @example Deposit token
+   *
+   * import { Provider, L1Signer, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
-   * const tokenDepositHandle = await signer.deposit({
+   * await signer.deposit({
    *   token: tokenL1,
-   *   amount: "10000000",
+   *   amount: 10_000_000,
    *   approveERC20: true,
    * });
-   * // Note that we wait not only for the L1 transaction to complete but also for it to be
-   * // processed by zkSync. If we want to wait only for the transaction to be processed on L1,
-   * // we can use `await tokenDepositHandle.waitL1Commit()`
-   * await tokenDepositHandle.wait();
-   *
-   * const ethDepositHandle = await signer.deposit({
-   *   token: utils.ETH_ADDRESS,
-   *   amount: "10000000",
-   * });
-   * // Note that we wait not only for the L1 transaction to complete but also for it to be
-   * // processed by zkSync. If we want to wait only for the transaction to be processed on L1,
-   * // we can use `await ethDepositHandle.waitL1Commit()`
-   * await ethDepositHandle.wait();
    */
   override async deposit(transaction: {
     token: Address;
@@ -688,14 +747,16 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x5C221E77624690fff6dd741493D735a17716c26B";
    * const gas = await signer.estimateGasDeposit({
    *   token: tokenL1,
-   *   amount: "10000000",
+   *   amount: 10_000_000,
    * });
    * console.log(`Gas: ${gas}`);
    */
@@ -722,14 +783,16 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
    * const tx = await signer.getDepositTx({
    *   token: tokenL1,
-   *   amount: "10000000",
+   *   amount: 10_000_000,
    * });
    */
   override async getDepositTx(transaction: {
@@ -752,17 +815,19 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    *
    * @example
    *
-   * import { Provider, L1Signer, types } from "zksync-ethers";
+   * import { Provider, L1Signer, Wallet, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
    * const fee = await signer.getFullRequiredDepositFee({
    *   token: tokenL1,
-   *   to: await wallet.getAddress(),
+   *   to: Wallet.createRandom().address,
    * });
    * console.log(`Fee: ${fee}`);
    */
@@ -787,47 +852,14 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    *
    * const CONTRACT_ADDRESS = "<CONTRACT_ADDRESS>";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
-   * const gasPrice = await signer.providerL1.getGasPrice();
-   *
-   * // The calldata can be encoded the same way as for Ethereum.
-   * // Here is an example of how to get the calldata from an ABI:
-   * const abi = [
-   *   {
-   *     inputs: [],
-   *     name: "increment",
-   *     outputs: [],
-   *     stateMutability: "nonpayable",
-   *     type: "function",
-   *   },
-   * ];
-   * const contractInterface = new ethers.utils.Interface(abi);
-   * const calldata = contractInterface.encodeFunctionData("increment", []);
-   * const l2GasLimit = 1000n;
-   *
-   * const txCostPrice = await signer.getBaseCost({
-   *   gasPrice,
-   *   calldataLength: ethers.utils.arrayify(calldata).length,
-   *   l2GasLimit,
-   * });
-   *
-   * console.log(`Executing the transaction will cost ${ethers.utils.formatEther(txCostPrice)} ETH`);
-   *
-   * const executeTx = await signer.requestExecute({
-   *   contractAddress: CONTRACT_ADDRESS,
-   *   calldata,
-   *   l2Value: 1,
-   *   l2GasLimit,
-   *   overrides: {
-   *     gasPrice,
-   *     value: txCostPrice,
-   *   },
-   * });
-   *
-   * await executeTx.wait();
+   * const WITHDRAWAL_HASH = "<WITHDRAWAL_TX_HASH>";
+   * const params = await signer.finalizeWithdrawalParams(WITHDRAWAL_HASH);
    */
   override async finalizeWithdrawalParams(
     withdrawalHash: BytesLike,
@@ -844,9 +876,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const WITHDRAWAL_HASH = "<WITHDRAWAL_TX_HASH>";
    * const finalizeWithdrawHandle = await signer.finalizeWithdrawal(WITHDRAWAL_HASH);
@@ -867,9 +901,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const WITHDRAWAL_HASH = "<WITHDRAWAL_TX_HASH>";
    * const isFinalized = await signer.isWithdrawalFinalized(WITHDRAWAL_HASH);
@@ -889,9 +925,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
    * const FAILED_DEPOSIT_HASH = "<FAILED_DEPOSIT_TX_HASH>";
    * const claimFailedDepositHandle = await signer.claimFailedDeposit(FAILED_DEPOSIT_HASH);
@@ -911,49 +949,17 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const CONTRACT_ADDRESS = "<CONTRACT_ADDRESS>";
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
-   *
-   * const gasPrice = await signer.providerL1.getGasPrice();
-   *
-   * // The calldata can be encoded the same way as for Ethereum.
-   * // Here is an example of how to get the calldata from an ABI:
-   * const abi = [
-   *   {
-   *     inputs: [],
-   *     name: "increment",
-   *     outputs: [],
-   *     stateMutability: "nonpayable",
-   *     type: "function",
-   *   },
-   * ];
-   * const contractInterface = new ethers.utils.Interface(abi);
-   * const calldata = contractInterface.encodeFunctionData("increment", []);
-   * const l2GasLimit = 1000n;
-   *
-   * const txCostPrice = await signer.getBaseCost({
-   *   gasPrice,
-   *   calldataLength: ethers.utils.arrayify(calldata).length,
-   *   l2GasLimit,
+   * await signer.requestExecute({
+   *     contractAddress: await signer.providerL2.getMainContractAddress(),
+   *     calldata: "0x",
+   *     l2Value: 7_000_000_000,
    * });
-   *
-   * console.log(`Executing the transaction will cost ${ethers.utils.formatEther(txCostPrice)} ETH`);
-   *
-   * const executeTx = await signer.requestExecute({
-   *   contractAddress: CONTRACT_ADDRESS,
-   *   calldata,
-   *   l2Value: 1,
-   *   l2GasLimit,
-   *   overrides: {
-   *     gasPrice,
-   *     value: txCostPrice,
-   *   },
-   * });
-   *
-   * await executeTx.wait();
    */
   override async requestExecute(transaction: {
     contractAddress: Address;
@@ -977,47 +983,19 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const CONTRACT_ADDRESS = "<CONTRACT_ADDRESS>";
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
-   *
-   * const gasPrice = await signer.providerL1.getGasPrice();
-   *
-   * // The calldata can be encoded the same way as for Ethereum.
-   * // Here is an example of how to get the calldata from an ABI:
-   * const abi = [
-   *   {
-   *     inputs: [],
-   *     name: "increment",
-   *     outputs: [],
-   *     stateMutability: "nonpayable",
-   *     type: "function",
-   *   },
-   * ];
-   * const contractInterface = new ethers.utils.Interface(abi);
-   * const calldata = contractInterface.encodeFunctionData("increment", []);
-   * const l2GasLimit = 1000n;
-   *
-   * const txCostPrice = await signer.getBaseCost({
-   *   gasPrice,
-   *   calldataLength: ethers.utils.arrayify(calldata).length,
-   *   l2GasLimit,
+   * const gas = await signer.estimateGasRequestExecute({
+   *     contractAddress: await signer.providerL2.getMainContractAddress(),
+   *     calldata: "0x",
+   *     l2Value: 7_000_000_000,
    * });
    *
-   * console.log(`Executing the transaction will cost ${ethers.utils.formatEther(txCostPrice)} ETH`);
-   *
-   * const executeTx = await signer.getRequestExecuteTx({
-   *   contractAddress: CONTRACT_ADDRESS,
-   *   calldata,
-   *   l2Value: 1,
-   *   l2GasLimit,
-   *   overrides: {
-   *     gasPrice,
-   *     value: txCostPrice,
-   *   },
-   * });
+   * console.log(`Gas: ${gas}`);
    */
   override async estimateGasRequestExecute(transaction: {
     contractAddress: Address;
@@ -1041,46 +1019,16 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const CONTRACT_ADDRESS = "<CONTRACT_ADDRESS>";
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
-   *
-   * const gasPrice = await signer.providerL1.getGasPrice();
-   *
-   * // The calldata can be encoded the same way as for Ethereum.
-   * // Here is an example of how to get the calldata from an ABI:
-   * const abi = [
-   *   {
-   *     inputs: [],
-   *     name: "increment",
-   *     outputs: [],
-   *     stateMutability: "nonpayable",
-   *     type: "function",
-   *   },
-   * ];
-   * const contractInterface = new ethers.utils.Interface(abi);
-   * const calldata = contractInterface.encodeFunctionData("increment", []);
-   * const l2GasLimit = 1000n;
-   *
-   * const txCostPrice = await signer.getBaseCost({
-   *   gasPrice,
-   *   calldataLength: ethers.utils.arrayify(calldata).length,
-   *   l2GasLimit,
-   * });
-   *
-   * console.log(`Executing the transaction will cost ${ethers.utils.formatEther(txCostPrice)} ETH`);
-   *
-   * const executeTx = await signer.getRequestExecuteTx({
-   *   contractAddress: CONTRACT_ADDRESS,
-   *   calldata,
-   *   l2Value: 1,
-   *   l2GasLimit,
-   *   overrides: {
-   *     gasPrice,
-   *     value: txCostPrice,
-   *   },
+   * const tx = await signer.getRequestExecuteTx({
+   *     contractAddress: await signer.providerL2.getMainContractAddress(),
+   *     calldata: "0x",
+   *     l2Value: 7_000_000_000,
    * });
    */
   override async getRequestExecuteTx(transaction: {
@@ -1108,9 +1056,11 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
-   * const provider = new ethers.providers.Web3Provider(window.ethereum);
-   * const zksyncProvider = Provider.getDefaultProvider(types.Network.Sepolia);
-   * const signer = L1Signer.from(provider.getSigner(), zksyncProvider);
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
    */
   static from(
     signer: ethers.providers.JsonRpcSigner,
@@ -1128,6 +1078,19 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
    * Connects to the L2 network using the `provider`.
    *
    * @param provider The provider instance for connecting to a L2 network.
+   *
+   * @example
+   *
+   * import { Provider, L1Signer, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const browserProvider = new ethers.providers.Web3Provider(window.ethereum);
+   * const signer = L1Signer.from(
+   *     browserProvider.getSigner(),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
+   *
+   * signer.connectToL2(Provider.getDefaultProvider(types.Network.Mainnet));
    */
   connectToL2(provider: Provider): this {
     this.providerL2 = provider;

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -964,7 +964,7 @@ export class L1Signer extends AdapterL1(ethers.providers.JsonRpcSigner) {
   override async requestExecute(transaction: {
     contractAddress: Address;
     calldata: string;
-    l2GasLimit: BigNumberish;
+    l2GasLimit?: BigNumberish;
     l2Value?: BigNumberish;
     factoryDeps?: BytesLike[];
     operatorTip?: BigNumberish;

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -531,7 +531,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
   override async requestExecute(transaction: {
     contractAddress: Address;
     calldata: string;
-    l2GasLimit: BigNumberish;
+    l2GasLimit?: BigNumberish;
     l2Value?: BigNumberish;
     factoryDeps?: BytesLike[];
     operatorTip?: BigNumberish;


### PR DESCRIPTION
# What :computer: 
* Add support for `zks` RPC methods in `Signer`.
