### PR TITLE
provide default mint value for non-eth based chains requestExecute tx

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1224,7 +1224,6 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
 
             const { ...tx } = transaction;
             tx.l2Value ??= BigNumber.from(0);
-            tx.mintValue ??= BigNumber.from(0);
             tx.operatorTip ??= BigNumber.from(0);
             tx.factoryDeps ??= [];
             tx.overrides ??= {};
@@ -1234,7 +1233,6 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
 
             const {
                 contractAddress,
-                mintValue,
                 l2Value,
                 calldata,
                 l2GasLimit,
@@ -1244,6 +1242,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
                 gasPerPubdataByte,
                 refundRecipient,
             } = tx;
+            let { mintValue } = tx;
 
             await insertGasPrice(this._providerL1(), overrides);
             const gasPriceForEstimation = (await overrides.maxFeePerGas) || (await overrides.gasPrice);
@@ -1255,6 +1254,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
             });
 
             overrides.value ??= isETHBaseToken ? baseCost.add(operatorTip).add(l2Value) : 0;
+            mintValue ??= isETHBaseToken ? 0 : baseCost.add(operatorTip).add(l2Value);
 
             await checkBaseCost(baseCost, isETHBaseToken ? overrides.value : mintValue);
 

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1253,15 +1253,16 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
                 gasLimit: l2GasLimit,
             });
 
-            overrides.value ??= isETHBaseToken ? baseCost.add(operatorTip).add(l2Value) : 0;
-            mintValue ??= isETHBaseToken ? 0 : baseCost.add(operatorTip).add(l2Value);
+            const l2Costs = baseCost.add(operatorTip).add(l2Value);
+            let providedValue =  isETHBaseToken ? overrides.value : mintValue;
+            providedValue ??= l2Costs;
 
-            await checkBaseCost(baseCost, isETHBaseToken ? overrides.value : mintValue);
+            await checkBaseCost(baseCost, providedValue);
 
             return await bridgehub.populateTransaction.requestL2TransactionDirect(
                 {
                     chainId,
-                    mintValue: isETHBaseToken ? await overrides.value : mintValue,
+                    mintValue: await providedValue,
                     l2Contract: contractAddress,
                     l2Value: l2Value,
                     l2Calldata: calldata,


### PR DESCRIPTION
# What :computer: 
* Updated mintValue calculation for `getRequestExecuteTx`

# Why :hand:
* We would like the SDK to automatically estimate the l2 costs for both ETH and non-ETH based chains
