### PR TITLE
Ethers V6: Use `isAddressEq` when comaparing addresses

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_GAS_PER_PUBDATA_LIMIT,
   EIP712_TX_TYPE,
   hashBytecode,
+  isAddressEq,
   serializeEip712,
 } from './utils';
 import {
@@ -494,7 +495,7 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
       const from = !transaction.from
         ? address
         : await ethers.resolveAddress(transaction.from);
-      if (from.toLowerCase() !== address.toLowerCase()) {
+      if (!isAddressEq(from, address)) {
         throw new Error('Transaction `from` address mismatch!');
       }
       const tx: TransactionLike = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ import {
   serializeEip712,
   sleep,
   eip712TxHash,
+  isAddressEq,
 } from './utils';
 import {Provider} from './provider';
 
@@ -401,7 +402,7 @@ export class Transaction extends ethers.Transaction {
           tx
         );
         assertArgument(
-          result.from.toLowerCase() === tx.from.toLowerCase(),
+          isAddressEq(result.from, tx.from),
           'from mismatch',
           'tx',
           tx

--- a/tests/integration/signer.test.ts
+++ b/tests/integration/signer.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../custom-matchers';
 const {expect} = chai;
 
-import {ITestnetERC20Token__factory} from '../../typechain';
+import {ITestnetERC20Token__factory} from '../../src/typechain';
 
 describe('L2VoidSigner', () => {
   const provider = Provider.getDefaultProvider();

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -3,7 +3,7 @@ import '../custom-matchers';
 import {Provider, types, utils, Wallet} from '../../src';
 import {ethers} from 'ethers';
 import * as fs from 'fs';
-import {ITestnetERC20Token__factory} from '../../typechain';
+import {ITestnetERC20Token__factory} from '../../src/typechain';
 import {
   IS_ETH_BASED,
   ADDRESS1,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,7 +7,7 @@ import {
   utils,
 } from '../src';
 import {ethers, Typed} from 'ethers';
-import {ITestnetERC20Token__factory} from '../typechain';
+import {ITestnetERC20Token__factory} from '../src/typechain';
 
 import Token from './files/Token.json';
 import Paymaster from './files/Paymaster.json';


### PR DESCRIPTION
# What :computer: 
* Use `isAddressEq` when comaparing addresses.