### PR TITLE
chore: run CI on push too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,9 @@
 name: Run tests
 on:
   workflow_dispatch:
+  push:
   pull_request:
-    branches:  [ main ]
+    branches:  [ main, ethers-v5 ]
     types: [ opened, reopened, synchronize ]
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
   pull_request:
-    branches:  [ main, ethers-v5 ]
+    branches:  [ main ]
     types: [ opened, reopened, synchronize ]
 
 permissions:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lint:fix": "gts fix",
     "watch": "tsc --watch",
     "types:fetch": "cd scripts && ./update-abi.sh && cd ../",
-    "types": "typechain --target ethers-v6 --out-dir src/typechain src/abi/*.json",
+    "types": "typechain --target ethers-v6 --out-dir src/typechain abi/*.json",
     "clean": "gts clean",
     "docs": "typedoc --out docs --hideInPageTOC true --useCodeBlocks true --includeVersion true  src/index.ts && cd scripts && ./post-process-doc.sh && cd ../"
   },

--- a/scripts/update-diamond-proxy.sh
+++ b/scripts/update-diamond-proxy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-output=$(docker exec local-setup_zksync_1 cat /deployed_contracts.log)
+output=$(docker exec local-setup-zksync-1 cat /deployed_contracts.log)
 address=$(echo "$output" | grep CONTRACTS_DIAMOND_PROXY_ADDR | cut -d'=' -f2 | tr -d '[:space:]')
 echo "{\"address\": \"$address\"}" > ../tests/files/diamondProxy.json


### PR DESCRIPTION
# What :computer: 
* Run CI also on the ethers-v5 branch and on push.
* adopt the test framework to work with the new version of local node
