### PR TITLE
fix(utils): resolve bug when `ETH_ADDRESS` is passed to `estimateDefaultBridgeDepositL2Gas`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -899,6 +899,9 @@ export async function getERC20DefaultBridgeData(
   l1TokenAddress: string,
   provider: ethers.providers.Provider
 ): Promise<string> {
+  if (isAddressEq(l1TokenAddress, LEGACY_ETH_ADDRESS)) {
+    l1TokenAddress = ETH_ADDRESS_IN_CONTRACTS;
+  }
   const token = IERC20Factory.connect(l1TokenAddress, provider);
 
   const name = isAddressEq(l1TokenAddress, ETH_ADDRESS_IN_CONTRACTS)
@@ -1192,7 +1195,7 @@ export async function estimateDefaultBridgeDepositL2Gas(
       providerL2,
       l1BridgeAddress,
       l2BridgeAddress,
-      token,
+      isAddressEq(token, LEGACY_ETH_ADDRESS) ? ETH_ADDRESS_IN_CONTRACTS : token,
       amount,
       to,
       bridgeData,

--- a/tests/integration/utils.test.ts
+++ b/tests/integration/utils.test.ts
@@ -2,12 +2,13 @@ import * as chai from 'chai';
 import '../custom-matchers';
 import {Provider, types, utils, EIP712Signer} from '../../src';
 import {BigNumber, ethers} from 'ethers';
-import {PRIVATE_KEY1, ADDRESS1} from '../utils';
+import {PRIVATE_KEY1, ADDRESS1, IS_ETH_BASED, ADDRESS2, DAI_L1} from '../utils';
 
 const {expect} = chai;
 
 describe('utils', () => {
   const provider = Provider.getDefaultProvider(types.Network.Localhost);
+  const ethProvider = ethers.getDefaultProvider('http://localhost:8545');
 
   describe('#isMessageSignatureCorrect()', () => {
     it('should return true for a valid message signature', async () => {
@@ -96,5 +97,69 @@ describe('utils', () => {
       );
       expect(result).to.be.false;
     });
+  });
+
+  describe('#estimateDefaultBridgeDepositL2Gas()', () => {
+    if(IS_ETH_BASED) {
+      it('should return estimation for ETH token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          utils.LEGACY_ETH_ADDRESS,
+          ethers.utils.parseEther('1'),
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result.isZero()).to.be.false;
+      });
+
+      it('should return estimation for DAI token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          DAI_L1,
+          5,
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result.isZero()).to.be.false;
+      });
+    } else {
+      it('should return estimation for ETH token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          utils.LEGACY_ETH_ADDRESS,
+          ethers.utils.parseEther('1'),
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result.isZero()).to.be.false;
+      });
+
+      it('should return estimation for base token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          await provider.getBaseTokenContractAddress(),
+          ethers.utils.parseEther('1'),
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result.isZero()).to.be.false;
+      });
+
+      it('should return estimation for DAI token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          DAI_L1,
+          5,
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result.isZero()).to.be.false;
+      });
+    }
   });
 });


### PR DESCRIPTION
# What :computer: 
* Fix the bug when `ETH_ADDRESS` is passed to `estimateDefaultBridgeDepositL2Gas` on non-ETH-based chain. The bug is resolved by converting `ETH_ADDRESS` to `ETH_ADDRESS_IN_CONTRACT` .