### PR TITLE
Ethers V6: Resolve bug when `ETH_ADDRESS` is passed to `estimateDefaultBridgeDepositL2Gas`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -865,6 +865,9 @@ export async function getERC20DefaultBridgeData(
   l1TokenAddress: string,
   provider: ethers.Provider
 ): Promise<string> {
+  if (isAddressEq(l1TokenAddress, LEGACY_ETH_ADDRESS)) {
+    l1TokenAddress = ETH_ADDRESS_IN_CONTRACTS;
+  }
   const token = IERC20__factory.connect(l1TokenAddress, provider);
 
   const name = isAddressEq(l1TokenAddress, ETH_ADDRESS_IN_CONTRACTS)
@@ -1159,7 +1162,7 @@ export async function estimateDefaultBridgeDepositL2Gas(
       providerL2,
       l1BridgeAddress,
       l2BridgeAddress,
-      token,
+      isAddressEq(token, LEGACY_ETH_ADDRESS) ? ETH_ADDRESS_IN_CONTRACTS : token,
       amount,
       to,
       bridgeData,

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -118,7 +118,7 @@ describe('Provider', () => {
   describe('#getBalance()', () => {
     it('should return an ETH balance of the account at `address`', async () => {
       const result = await provider.getBalance(ADDRESS1);
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
 
     it('should return a DAI balance of the account at `address`', async () => {
@@ -127,7 +127,7 @@ describe('Provider', () => {
         'latest',
         await provider.l2TokenAddress(DAI_L1)
       );
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
@@ -611,7 +611,7 @@ describe('Provider', () => {
         to: ADDRESS1,
         from: ADDRESS1,
       });
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
 
     it('should return a gas estimation of the withdraw transaction with paymaster', async () => {
@@ -630,7 +630,7 @@ describe('Provider', () => {
           innerInput: new Uint8Array(),
         }),
       });
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
@@ -642,7 +642,7 @@ describe('Provider', () => {
         to: ADDRESS2,
         from: ADDRESS1,
       });
-      expect(result > 0).to.be.be.true;
+      expect(result > 0n).to.be.be.true;
     });
 
     it('should return a gas estimation of the transfer transaction with paymaster', async () => {
@@ -658,7 +658,7 @@ describe('Provider', () => {
           innerInput: new Uint8Array(),
         }),
       });
-      expect(result > 0).to.be.be.true;
+      expect(result > 0n).to.be.be.true;
     });
   });
 
@@ -684,7 +684,7 @@ describe('Provider', () => {
         caller: ADDRESS1,
         l2Value: 7_000_000_000,
       });
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
@@ -706,7 +706,7 @@ describe('Provider', () => {
         to: await provider.l2TokenAddress(DAI_L1),
         data: utils.IERC20.encodeFunctionData('approve', [ADDRESS2, 1]),
       });
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
 
     it('should return a gas estimation of the EIP712 transaction', async () => {
@@ -718,7 +718,7 @@ describe('Provider', () => {
           gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
         },
       });
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 

--- a/tests/integration/signer.test.ts
+++ b/tests/integration/signer.test.ts
@@ -42,7 +42,7 @@ describe('L2VoidSigner', () => {
   describe('#getBalance()', () => {
     it('should return the `L2VoidSigner` balance', async () => {
       const result = await signer.getBalance();
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
@@ -366,7 +366,7 @@ describe('L1VoidSigner', async () => {
   describe('#getBalanceL1()', () => {
     it('should return a L1 balance', async () => {
       const result = await signer.getBalanceL1();
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
@@ -735,7 +735,7 @@ describe('L1VoidSigner', async () => {
           amount: amount,
           refundRecipient: await signer.getAddress(),
         });
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should return gas estimation for base token deposit transaction', async () => {
@@ -761,7 +761,7 @@ describe('L1VoidSigner', async () => {
           amount: amount,
           refundRecipient: await signer.getAddress(),
         });
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should return gas estimation for DAI deposit transaction', async () => {
@@ -1107,7 +1107,7 @@ describe('L1VoidSigner', async () => {
         calldata: '0x',
         l2Value: 7_000_000_000,
       });
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 

--- a/tests/integration/smart-account.test.ts
+++ b/tests/integration/smart-account.test.ts
@@ -118,7 +118,7 @@ describe('SmartAccount', async () => {
   describe('#getBalance()', () => {
     it('should return a `SmartAccount` balance', async () => {
       const result = await account.getBalance();
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 

--- a/tests/integration/utils.test.ts
+++ b/tests/integration/utils.test.ts
@@ -110,7 +110,7 @@ describe('utils', () => {
           ADDRESS2,
           ADDRESS1,
         );
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       });
 
       it('should return estimation for DAI token', async () => {

--- a/tests/integration/utils.test.ts
+++ b/tests/integration/utils.test.ts
@@ -2,12 +2,13 @@ import * as chai from 'chai';
 import '../custom-matchers';
 import {Provider, types, utils, EIP712Signer} from '../../src';
 import {ethers} from 'ethers';
-import {ADDRESS1, PRIVATE_KEY1} from '../utils';
+import {PRIVATE_KEY1, ADDRESS1, IS_ETH_BASED, ADDRESS2, DAI_L1} from '../utils';
 
 const {expect} = chai;
 
 describe('utils', () => {
   const provider = Provider.getDefaultProvider(types.Network.Localhost);
+  const ethProvider = ethers.getDefaultProvider('http://localhost:8545');
 
   describe('#isMessageSignatureCorrect()', () => {
     it('should return true for a valid message signature', async () => {
@@ -96,5 +97,69 @@ describe('utils', () => {
       );
       expect(result).to.be.false;
     });
+  });
+
+  describe('#estimateDefaultBridgeDepositL2Gas()', () => {
+    if(IS_ETH_BASED) {
+      it('should return estimation for ETH token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          utils.LEGACY_ETH_ADDRESS,
+          ethers.parseEther('1'),
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result > 0).to.be.true;
+      });
+
+      it('should return estimation for DAI token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          DAI_L1,
+          5,
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result > 0n).to.be.false;
+      });
+    } else {
+      it('should return estimation for ETH token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          utils.LEGACY_ETH_ADDRESS,
+          ethers.parseEther('1'),
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result > 0n).to.be.true;
+      });
+
+      it('should return estimation for base token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          await provider.getBaseTokenContractAddress(),
+          ethers.parseEther('1'),
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result > 0n).to.be.true;
+      });
+
+      it('should return estimation for DAI token', async () => {
+        const result = await utils.estimateDefaultBridgeDepositL2Gas(
+          ethProvider,
+          provider,
+          DAI_L1,
+          5,
+          ADDRESS2,
+          ADDRESS1,
+        );
+        expect(result > 0n).to.be.true;
+      });
+    }
   });
 });

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -85,14 +85,14 @@ describe('Wallet', () => {
   describe('#getBalanceL1()', () => {
     it('should return a L1 balance', async () => {
       const result = await wallet.getBalanceL1();
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
   describe('#getAllowanceL1()', () => {
     it('should return an allowance of L1 token', async () => {
       const result = await wallet.getAllowanceL1(DAI_L1);
-      expect(result >= 0).to.be.true;
+      expect(result >= 0n).to.be.true;
     });
   });
 
@@ -144,7 +144,7 @@ describe('Wallet', () => {
   describe('#getBalance()', () => {
     it('should return a `Wallet` balance', async () => {
       const result = await wallet.getBalance();
-      expect(result > 0).to.be.true;
+      expect(result > 0n).to.be.true;
     });
   });
 
@@ -699,7 +699,7 @@ describe('Wallet', () => {
           amount: amount,
           refundRecipient: await wallet.getAddress(),
         });
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should return gas estimation for base token deposit transaction', async () => {
@@ -723,7 +723,7 @@ describe('Wallet', () => {
           amount: amount,
           refundRecipient: await wallet.getAddress(),
         });
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should return gas estimation for DAI deposit transaction', async () => {
@@ -864,7 +864,7 @@ describe('Wallet', () => {
         expect(result).not.to.be.null;
         expect(l2BalanceAfterDeposit - l2BalanceBeforeDeposit >= amount).to.be
           .true;
-        expect(l1BalanceBeforeDeposit - l1BalanceAfterDeposit >= 0).to.be.true;
+        expect(l1BalanceBeforeDeposit - l1BalanceAfterDeposit >= 0n).to.be.true;
       }).timeout(20_000);
 
       it('should deposit DAI to L2 network', async () => {
@@ -1387,7 +1387,7 @@ describe('Wallet', () => {
           calldata: '0x',
           l2Value: 7_000_000_000,
         });
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       });
     } else {
       it('should return gas estimation for request execute transaction', async () => {
@@ -1407,7 +1407,7 @@ describe('Wallet', () => {
         ).wait();
 
         const result = await wallet.estimateGasRequestExecute(tx);
-        expect(result > 0).to.be.true;
+        expect(result > 0n).to.be.true;
       }).timeout(10_000);
     }
   });


### PR DESCRIPTION
# What :computer: 
* Fix the bug when `ETH_ADDRESS` is passed to `estimateDefaultBridgeDepositL2Gas` on non-ETH-based chain. The bug is resolved by converting `ETH_ADDRESS` to `ETH_ADDRESS_IN_CONTRACT` .