### PR TITLE
Fix: getPriorityOpResponse correctly assigns waitL1Commit to l2Response object

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -845,7 +845,9 @@ export function JsonRpcApiProvider<
     ): Promise<PriorityOpResponse> {
       const l2Response = {...l1TxResponse} as PriorityOpResponse;
 
-      l2Response.waitL1Commit = l2Response.wait;
+      l2Response.waitL1Commit = l1TxResponse.wait.bind(
+        l1TxResponse
+      ) as PriorityOpResponse['wait'];
       l2Response.wait = async () => {
         const l2Tx = await this.getL2TransactionFromPriorityOp(l1TxResponse);
         return await l2Tx.wait();

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,0 +1,49 @@
+import {expect} from 'chai';
+import {Provider} from '../../src';
+import {TransactionResponse} from 'ethers';
+import {Signature} from 'ethers';
+
+describe('Provider', () => {
+  it('should correctly initialize and assign function properties in getPriorityOpResponse', async () => {
+    const provider = new Provider();
+    const l1TxResponse = new TransactionResponse(
+      {
+        hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        from: '0xabcdef1234567890abcdef1234567890abcdef1234',
+        blockHash:
+          '0xabcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        blockNumber: 123456,
+        to: '0xabcdef1234567890abcdef1234567890abcdef1234',
+        type: 2,
+        nonce: 42,
+        gasLimit: 2000000n,
+        index: 3,
+        gasPrice: 1000000000n,
+        data: '0x',
+        value: 0n,
+        chainId: 1337n,
+        // not used in tested code, keep the test simple
+        signature: null as unknown as Signature,
+        maxPriorityFeePerGas: null,
+        maxFeePerGas: null,
+        accessList: null,
+      },
+      provider
+    );
+
+    const priorityOpResponse =
+      await provider.getPriorityOpResponse(l1TxResponse);
+    expect(typeof priorityOpResponse.waitL1Commit).to.equal(
+      'function',
+      'The waitL1Commit function should be properly initialized'
+    );
+    expect(typeof priorityOpResponse.wait).to.equal(
+      'function',
+      'The wait function should be properly initialized'
+    );
+    expect(typeof priorityOpResponse.waitFinalize).to.equal(
+      'function',
+      'The waitFinalize function should be properly initialized'
+    );
+  });
+});


### PR DESCRIPTION
# What :computer: 
* This fixes a bug in the provider method `getPriorityOpResponse`. Before, the `waitL1Commit` of the result object would have been `undefined`.

# Why :hand:
*  I noticed while debugging a project using zksync-ethers that the `waitL1Commit` function is not defined after bridging ERC20 from L1 (Sepolia) to L2. We can also verify this by running the test in this PR and using the old code, it would fail (the mentioned function is undefined). With the spread operator, anything from the object's prototype will not be included.

# Evidence :camera:
Please see the included test, it can be run with the old code and would fail, which is not the intended result.

Thanks a lot for taking a look.