### PR TITLE
Ethers V6: Fix compatibility issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: Run tests
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
   pull_request:
     branches:  [ main ]
@@ -31,15 +33,10 @@ jobs:
         run: |
           git clone https://github.com/matter-labs/local-setup.git
           pushd local-setup
-          docker-compose up -d
+          ./start.sh v22-before-shared-bridge
           popd
       - name: Wait for local-setup to be ready
         run: yarn test:wait
-      - name: Prepare proxy
-        run: |
-          pushd scripts
-          ./update-diamond-proxy.sh
-          popd
       - name: Prepare environment
         run: yarn test:prepare
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 coverage
 docs
 tests/build
+typechain
+!src/typechain
 
 .idea
 .vscode

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "files": [
     "build/",
     "abi/",
-    "src/"
+    "src/",
+    "typechain"
   ],
   "dependencies": {},
   "devDependencies": {
@@ -66,7 +67,7 @@
     "lint:fix": "gts fix",
     "watch": "tsc --watch",
     "types:fetch": "cd scripts && ./update-abi.sh && cd ../",
-    "types": "typechain --target ethers-v6 --out-dir src/typechain abi/*.json",
+    "types": "typechain --target ethers-v6 --out-dir src/typechain abi/*.json && ncp src/typechain typechain",
     "clean": "gts clean",
     "docs": "typedoc --out docs --hideInPageTOC true --useCodeBlocks true --includeVersion true  src/index.ts && cd scripts && ./post-process-doc.sh && cd ../"
   },

--- a/src/paymaster-utils.ts
+++ b/src/paymaster-utils.ts
@@ -51,7 +51,7 @@ export function getGeneralPaymasterInput(
  * @param paymasterAddress The non-zero paymaster address.
  * @param paymasterInput The input data for the paymaster.
  *
- * @example Create general-based parameters
+ * @example Create general-based parameters.
  *
  * const paymasterAddress = "0x0a67078A35745947A37A552174aFe724D8180c25";
  * const paymasterParams = utils.getPaymasterParams(paymasterAddress, {
@@ -59,7 +59,7 @@ export function getGeneralPaymasterInput(
  *   innerInput: new Uint8Array(),
  * });
  *
- * @example Create approval-based parameters
+ * @example Create approval-based parameters.
  *
  * const result = utils.getPaymasterParams("0x0a67078A35745947A37A552174aFe724D8180c25", {
  *   type: "ApprovalBased",

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2145,7 +2145,7 @@ export class BrowserProvider extends JsonRpcApiProvider(
     erc20L1: string | undefined;
     erc20L2: string | undefined;
     wethL1: string | undefined;
-    wethL2: string | undefined
+    wethL2: string | undefined;
   }> {
     return super.getDefaultBridgeAddresses();
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1047,12 +1047,12 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    *
    * const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-   * const txHandle = await provider.getTransaction(TX_HASH);
+   * const tx = await provider.getTransaction(TX_HASH);
    *
    * // Wait until the transaction is processed by the server.
-   * await txHandle.wait();
+   * await tx.wait();
    * // Wait until the transaction is finalized.
-   * await txHandle.waitFinalize();
+   * await tx.waitFinalize();
    */
   override async getTransaction(txHash: string): Promise<TransactionResponse> {
     return super.getTransaction(txHash);
@@ -1798,6 +1798,10 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    * Creates a new `Provider` from provided URL or network name.
    *
    * @param zksyncNetwork The type of zkSync network.
+   *
+   * import { Provider, types } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    */
   static getDefaultProvider(
     zksyncNetwork: ZkSyncNetwork = ZkSyncNetwork.Localhost
@@ -1914,12 +1918,12 @@ export class BrowserProvider extends JsonRpcApiProvider(
    * const provider = new BrowserProvider(window.ethereum);
    *
    * const TX_HASH = "<YOUR_TX_HASH_ADDRESS>";
-   * const txHandle = await provider.getTransaction(TX_HASH);
+   * const tx = await provider.getTransaction(TX_HASH);
    *
    * // Wait until the transaction is processed by the server.
-   * await txHandle.wait();
+   * await tx.wait();
    * // Wait until the transaction is finalized.
-   * await txHandle.waitFinalize();
+   * await tx.waitFinalize();
    */
   override async getTransaction(txHash: string): Promise<TransactionResponse> {
     return super.getTransaction(txHash);
@@ -2125,6 +2129,25 @@ export class BrowserProvider extends JsonRpcApiProvider(
    */
   override async getTestnetPaymasterAddress(): Promise<Address | null> {
     return super.getTestnetPaymasterAddress();
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
+   * import { BrowserProvider } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * console.log(`Default bridges: ${utils.toJSON(await provider.getDefaultBridgeAddresses())}`);
+   */
+  override async getDefaultBridgeAddresses(): Promise<{
+    erc20L1: string | undefined;
+    erc20L2: string | undefined;
+    wethL1: string | undefined;
+    wethL2: string | undefined
+  }> {
+    return super.getDefaultBridgeAddresses();
   }
 
   /**

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -166,7 +166,6 @@ export class EIP712Signer {
  * providing only L2 operations.
  *
  * @see {@link L1Signer} for L1 operations.
- *
  */
 export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
   public override provider!: Provider;
@@ -288,6 +287,49 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    *
    * @example Withdraw ETH.
    *
+   * import { BrowserProvider, Provider, types, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const browserProvider = new BrowserProvider(window.ethereum);
+   * const signer = Signer.from(
+   *     await browserProvider.getSigner(),
+   *     Number((await browserProvider.getNetwork()).chainId),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = await signer.withdraw({
+   *   token: utils.ETH_ADDRESS,
+   *   amount: 10_000_000n,
+   * });
+   *
+   * @example Withdraw ETH using paymaster to facilitate fee payment with an ERC20 token.
+   *
+   * import { BrowserProvider, Provider, types, utils } from "zksync-ethers";
+   *
+   * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
+   * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
+   *
+   * const browserProvider = new BrowserProvider(window.ethereum);
+   * const signer = Signer.from(
+   *     await browserProvider.getSigner(),
+   *     Number((await browserProvider.getNetwork()).chainId),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
+   *
+   * const tx = await signer.withdraw({
+   *   token: utils.ETH_ADDRESS,
+   *   amount: 10_000_000n,
+   *   paymasterParams: utils.getPaymasterParams(paymaster, {
+   *     type: "ApprovalBased",
+   *     token: token,
+   *     minimalAllowance: 1,
+   *     innerInput: new Uint8Array(),
+   *   }),
+   * });
+   *
+   * @example Withdraw token.
+   *
    * import { BrowserProvider, Provider, types } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
@@ -301,10 +343,10 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
    * const tx = await signer.withdraw({
    *   token: tokenL2,
-   *   amount: 10_000_000,
+   *   amount: 10_000_000n,
    * });
    *
-   * @example Withdraw ETH using paymaster to facilitate fee payment with an ERC20 token.
+   * @example Withdraw token using paymaster to facilitate fee payment with an ERC20 token.
    *
    * import { BrowserProvider, Provider, types } from "zksync-ethers";
    *
@@ -319,7 +361,7 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    * );
    *
    * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
-   * const tx = await wallet.withdraw({
+   * const tx = await signer.withdraw({
    *   token: tokenL2,
    *   amount: 10_000_000n,
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
@@ -356,6 +398,7 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    *     Provider.getDefaultProvider(types.Network.Sepolia)
    * );
    *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
    * const tx = await signer.transfer({
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
@@ -381,6 +424,61 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    * );
    *
    * const tx = signer.transfer({
+   *   to: Wallet.createRandom().address,
+   *   amount: ethers.parseEther("0.01"),
+   *   paymasterParams: utils.getPaymasterParams(paymaster, {
+   *     type: "ApprovalBased",
+   *     token: token,
+   *     minimalAllowance: 1,
+   *     innerInput: new Uint8Array(),
+   *   }),
+   * });
+   *
+   * const receipt = await tx.wait();
+   *
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
+   *
+   * @example Transfer token.
+   *
+   * import { BrowserProvider, Provider, Wallet, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const browserProvider = new BrowserProvider(window.ethereum);
+   * const signer = Signer.from(
+   *     await browserProvider.getSigner(),
+   *     Number((await browserProvider.getNetwork()).chainId),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = await signer.transfer({
+   *   token: tokenL2,
+   *   to: Wallet.createRandom().address,
+   *   amount: ethers.parseEther("0.01"),
+   * });
+   *
+   * const receipt = await tx.wait();
+   *
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
+   *
+   * @example Transfer token using paymaster to facilitate fee payment with an ERC20 token.
+   *
+   * import { BrowserProvider, Provider, Wallet, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
+   * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
+   *
+   * const browserProvider = new BrowserProvider(window.ethereum);
+   * const signer = await Signer.from(
+   *     await browserProvider.getSigner(),
+   *     Number((await browserProvider.getNetwork()).chainId),
+   *     Provider.getDefaultProvider(types.Network.Sepolia)
+   * );
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = signer.transfer({
+   *   token: tokenL2,
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
@@ -722,7 +820,7 @@ export class L1Signer extends AdapterL1(ethers.JsonRpcSigner) {
   /**
    * @inheritDoc
    *
-   * @example Deposit ETH
+   * @example Deposit ETH.
    *
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
@@ -738,7 +836,7 @@ export class L1Signer extends AdapterL1(ethers.JsonRpcSigner) {
    *   amount: 10_000_000n,
    * });
    *
-   * @example Deposit token
+   * @example Deposit token.
    *
    * import { Provider, L1Signer, types } from "zksync-ethers";
    * import { ethers } from "ethers";
@@ -915,7 +1013,7 @@ export class L1Signer extends AdapterL1(ethers.JsonRpcSigner) {
    * );
    *
    * const WITHDRAWAL_HASH = "<WITHDRAWAL_TX_HASH>";
-   * const finalizeWithdrawHandle = await signer.finalizeWithdrawal(WITHDRAWAL_HASH);
+   * const finalizeWithdrawTx = await signer.finalizeWithdrawal(WITHDRAWAL_HASH);
    */
   override async finalizeWithdrawal(
     withdrawalHash: BytesLike,
@@ -964,7 +1062,7 @@ export class L1Signer extends AdapterL1(ethers.JsonRpcSigner) {
    * );
    *
    * const FAILED_DEPOSIT_HASH = "<FAILED_DEPOSIT_TX_HASH>";
-   * const claimFailedDepositHandle = await signer.claimFailedDeposit(FAILED_DEPOSIT_HASH);
+   * const claimFailedDepositTx = await signer.claimFailedDeposit(FAILED_DEPOSIT_HASH);
    */
   override async claimFailedDeposit(
     depositHash: BytesLike,
@@ -1283,7 +1381,13 @@ export class L1VoidSigner extends AdapterL1(ethers.VoidSigner) {
    *
    * @example
    *
+   * import { L1VoidSigner } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   *
+   * const signer = new L1VoidSigner("<ADDRESS>);
+   * const balance = await signer.getBalance();
    */
   async getBalance(
     token?: Address,

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -178,7 +178,8 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
   }
 
   override _providerL2() {
-    return this.providerL2!;
+    // Make it compatible when singer is created with Web3Provider.getSigner()
+    return this.providerL2 ? this.providerL2 : this.provider;
   }
 
   /**
@@ -355,7 +356,7 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    *     Provider.getDefaultProvider(types.Network.Sepolia)
    * );
    *
-   * const tx = signer.transfer({
+   * const tx = await signer.transfer({
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    * });
@@ -373,7 +374,7 @@ export class Signer extends AdapterL2(ethers.JsonRpcSigner) {
    * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
    *
    * const browserProvider = new BrowserProvider(window.ethereum);
-   * const signer = Signer.from(
+   * const signer = await Signer.from(
    *     await browserProvider.getSigner(),
    *     Number((await browserProvider.getNetwork()).chainId),
    *     Provider.getDefaultProvider(types.Network.Sepolia)

--- a/src/smart-account-utils.ts
+++ b/src/smart-account-utils.ts
@@ -8,7 +8,7 @@ import {TransactionLike, TransactionBuilder, PayloadSigner} from './types';
  * @param payload The payload that needs to be signed.
  * @param secret The ECDSA private key.
  *
- * @example Sign EIP712 transaction hash
+ * @example Sign EIP712 transaction hash.
  *
  * import { EIP712Signer, types, utils } from "zksync-ethers";
  *
@@ -24,7 +24,7 @@ import {TransactionLike, TransactionBuilder, PayloadSigner} from './types';
  * const txHash = EIP712Signer.getSignedDigest(tx);
  * const result = await utils.signPayloadWithECDSA(txHash, PRIVATE_KEY);
  *
- * @example Sign message hash
+ * @example Sign message hash.
  *
  * import { utils } from "zksync-ethers";
  * import { hashMessage } from "ethers";
@@ -36,7 +36,7 @@ import {TransactionLike, TransactionBuilder, PayloadSigner} from './types';
  *
  * const result = await utils.signPayloadWithECDSA(messageHash, PRIVATE_KEY);
  *
- * @example Sign typed data hash
+ * @example Sign typed data hash.
  *
  * import { utils } from "zksync-ethers";
  * import { TypedDataEncoder } from "ethers";
@@ -72,7 +72,7 @@ export const signPayloadWithECDSA: PayloadSigner = async (
  *
  * @throws {Error} If the `secret` is not an array of at least two elements.
  *
- * @example Sign EIP712 transaction hash
+ * @example Sign EIP712 transaction hash.
  *
  * import { EIP712Signer, types, utils } from "zksync-ethers";
  *
@@ -89,7 +89,7 @@ export const signPayloadWithECDSA: PayloadSigner = async (
  * const txHash = EIP712Signer.getSignedDigest(tx);
  * const result = await utils.signPayloadWithMultipleECDSA(typedDataHash, [PRIVATE_KEY1, PRIVATE_KEY2]);
  *
- * @example Sign message hash
+ * @example Sign message hash.
  *
  * import { utils } from "zksync-ethers";
  * import { hashMessage } from "ethers";
@@ -102,7 +102,7 @@ export const signPayloadWithECDSA: PayloadSigner = async (
  *
  * const result = await utils.signPayloadWithMultipleECDSA(typedDataHash, [PRIVATE_KEY1, PRIVATE_KEY2]);
  *
- * @example Sign typed data hash
+ * @example Sign typed data hash.
  *
  * import { utils } from "zksync-ethers";
  * import { TypedDataEncoder } from "ethers";

--- a/src/smart-account.ts
+++ b/src/smart-account.ts
@@ -437,7 +437,7 @@ export class SmartAccount extends AbstractSigner {
    *
    * @returns A Promise resolving to a withdrawal transaction response.
    *
-   * @example Withdraw ETH
+   * @example Withdraw ETH.
    *
    * import { SmartAccount, Provider, types, utils } from "zksync-ethers";
    *
@@ -450,9 +450,9 @@ export class SmartAccount extends AbstractSigner {
    *   provider
    * );
    *
-   * const tokenWithdrawHandle = await account.withdraw({
+   * const tokenWithdrawTx = await account.withdraw({
    *   token: utils.ETH_ADDRESS,
-   *   amount: 10_000_000,
+   *   amount: 10_000_000n,
    * });
    *
    * @example Withdraw ETH using paymaster to facilitate fee payment with an ERC20 token.
@@ -471,9 +471,9 @@ export class SmartAccount extends AbstractSigner {
    *   provider
    * );
    *
-   * const tokenWithdrawHandle = await account.withdraw({
+   * const tokenWithdrawTx = await account.withdraw({
    *   token: utils.ETH_ADDRESS,
-   *   amount: 10_000_000,
+   *   amount: 10_000_000n,
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
    *     token: token,
@@ -511,7 +511,7 @@ export class SmartAccount extends AbstractSigner {
    *
    * @returns A Promise resolving to a transfer transaction response.
    *
-   * @example Transfer ETH
+   * @example Transfer ETH.
    *
    * import { SmartAccount, Wallet, Provider, types } from "zksync-ethers";
    * import { ethers } from "ethers";
@@ -525,17 +525,17 @@ export class SmartAccount extends AbstractSigner {
    *   provider
    * );
    *
-   * const transferHandle = await account.transfer({
+   * const transferTx = await account.transfer({
    *   token: utils.ETH_ADDRESS,
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    * });
    *
-   * const tx = await transferHandle.wait();
+   * const tx = await transferTx.wait();
    *
    * console.log(`The sum of ${tx.value} ETH was transferred to ${tx.to}`);
    *
-   * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token
+   * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token.
    *
    * import { SmartAccount, Wallet, Provider, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
@@ -552,7 +552,7 @@ export class SmartAccount extends AbstractSigner {
    *   provider
    * );
    *
-   * const transferHandle = await account.transfer({
+   * const transferTx = await account.transfer({
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
@@ -563,7 +563,7 @@ export class SmartAccount extends AbstractSigner {
    *   }),
    * });
    *
-   * const tx = await transferHandle.wait();
+   * const tx = await transferTx.wait();
    *
    * console.log(`The sum of ${tx.value} ETH was transferred to ${tx.to}`);
    */

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -58,7 +58,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -78,7 +78,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -101,7 +101,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -126,7 +126,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -151,7 +151,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -173,7 +173,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -183,9 +183,9 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
    *
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
-   * const txHandle = await wallet.approveERC20(tokenL1, "10000000");
+   * const tx = await wallet.approveERC20(tokenL1, "10000000");
    *
-   * await txHandle.wait();
+   * await tx.wait();
    */
   override async approveERC20(
     token: Address,
@@ -202,7 +202,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -224,9 +224,29 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
   /**
    * @inheritDoc
    *
-   * @example
+   * @example Deposit ETH.
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const ethProvider = ethers.getDefaultProvider("sepolia");
+   * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
+   *
+   * const tx = await wallet.deposit({
+   *   token: utils.ETH_ADDRESS,
+   *   amount: 10_000_000n,
+   * });
+   * // Note that we wait not only for the L1 transaction to complete but also for it to be
+   * // processed by zkSync. If we want to wait only for the transaction to be processed on L1,
+   * // we can use `await tx.waitL1Commit()`
+   * await tx.wait();
+   *
+   * @example Deposit token.
+   *
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -236,24 +256,15 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
    *
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
-   * const tokenDepositHandle = await wallet.deposit({
+   * const tx = await wallet.deposit({
    *   token: tokenL1,
-   *   amount: "10000000",
+   *   amount: 10_000_000n,
    *   approveERC20: true,
    * });
    * // Note that we wait not only for the L1 transaction to complete but also for it to be
    * // processed by zkSync. If we want to wait only for the transaction to be processed on L1,
-   * // we can use `await tokenDepositHandle.waitL1Commit()`
-   * await tokenDepositHandle.wait();
-   *
-   * const ethDepositHandle = await wallet.deposit({
-   *   token: utils.ETH_ADDRESS,
-   *   amount: "10000000",
-   * });
-   * // Note that we wait not only for the L1 transaction to complete but also for it to be
-   * // processed by zkSync. If we want to wait only for the transaction to be processed on L1,
-   * // we can use `await ethDepositHandle.waitL1Commit()`
-   * await ethDepositHandle.wait();
+   * // we can use `await tx.waitL1Commit()`
+   * await tx.wait();
    */
   override async deposit(transaction: {
     token: Address;
@@ -277,7 +288,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -289,7 +300,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const tokenL1 = "0x5C221E77624690fff6dd741493D735a17716c26B";
    * const gas = await wallet.estimateGasDeposit({
    *   token: tokenL1,
-   *   amount: "10000000",
+   *   amount: 10_000_000n,
    * });
    * console.log(`Gas: ${gas}`);
    */
@@ -313,7 +324,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -325,7 +336,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
    * const tx = await wallet.getDepositTx({
    *   token: tokenL1,
-   *   amount: "10000000",
+   *   amount: "10_000_000n,
    * });
    */
   override async getDepositTx(transaction: {
@@ -348,7 +359,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -380,7 +391,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -404,7 +415,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -414,7 +425,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
    *
    * const WITHDRAWAL_HASH = "<WITHDRAWAL_TX_HASH>";
-   * const finalizeWithdrawHandle = await wallet.finalizeWithdrawal(WITHDRAWAL_HASH);
+   * const finalizeWithdrawTx = await wallet.finalizeWithdrawal(WITHDRAWAL_HASH);
    */
   override async finalizeWithdrawal(
     withdrawalHash: BytesLike,
@@ -429,7 +440,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -453,7 +464,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -463,7 +474,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const wallet = new Wallet(PRIVATE_KEY, provider, ethProvider);
    *
    * const FAILED_DEPOSIT_HASH = "<FAILED_DEPOSIT_TX_HASH>";
-   * const claimFailedDepositHandle = await wallet.claimFailedDeposit(FAILED_DEPOSIT_HASH);
+   * const claimFailedDepositTx = await wallet.claimFailedDeposit(FAILED_DEPOSIT_HASH);
    */
   override async claimFailedDeposit(
     depositHash: BytesLike,
@@ -477,7 +488,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -513,7 +524,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -549,7 +560,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -582,9 +593,9 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
   /**
    * @inheritDoc
    *
-   * @example Get ETH balance
+   * @example Get ETH balance.
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -595,7 +606,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * console.log(`ETH balance: ${await wallet.getBalance()}`);
    *
-   * @example Get token balance
+   * @example Get token balance.
    *
    * import { Wallet, Provider, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
@@ -622,7 +633,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -642,7 +653,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -662,7 +673,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -683,9 +694,9 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
   /**
    * @inheritDoc
    *
-   * @example Withdraw ETH
+   * @example Withdraw ETH.
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    *
@@ -693,14 +704,14 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
    * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
-   * const tokenWithdrawHandle = await wallet.withdraw({
+   * const tx = await wallet.withdraw({
    *   token: utils.ETH_ADDRESS,
-   *   amount: 10_000_000,
+   *   amount: 10_000_000n,
    * });
    *
    * @example Withdraw ETH using paymaster to facilitate fee payment with an ERC20 token.
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
@@ -709,9 +720,47 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const tokenWithdrawHandle = await wallet.withdraw({
+   * const tx = await wallet.withdraw({
    *   token: utils.ETH_ADDRESS,
+   *   amount: 10_000_000n,
+   *   paymasterParams: utils.getPaymasterParams(paymaster, {
+   *     type: "ApprovalBased",
+   *     token: token,
+   *     minimalAllowance: 1,
+   *     innerInput: new Uint8Array(),
+   *   }),
+   * });
+   *
+   * @example Withdraw token.
+   *
+   * import { Wallet, Provider, types } from "zksync-ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const wallet = new Wallet(PRIVATE_KEY, provider);
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = await wallet.withdraw({
+   *   token: tokenL2,
    *   amount: 10_000_000,
+   * });
+   *
+   * @example Withdraw token using paymaster to facilitate fee payment with an ERC20 token.
+   *
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
+   * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const wallet = new Wallet(PRIVATE_KEY, provider);
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = await wallet.withdraw({
+   *   token: tokenL2,
+   *   amount: 10_000_000n,
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
    *     type: "ApprovalBased",
    *     token: token,
@@ -734,7 +783,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
   /**
    * @inheritDoc
    *
-   * @example Transfer ETH
+   * @example Transfer ETH.
    *
    * import { Wallet, Provider, types } from "zksync-ethers";
    *
@@ -743,18 +792,19 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const transferHandle = await wallet.transfer({
+   * const tx = await wallet.transfer({
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    * });
    *
-   * const tx = await transferHandle.wait();
+   * const receipt = await tx.wait();
    *
-   * console.log(`The sum of ${tx.value} ETH was transferred to ${tx.to}`);
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
    *
-   * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token
+   * @example Transfer ETH using paymaster to facilitate fee payment with an ERC20 token.
    *
    * import { Wallet, Provider, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
@@ -763,7 +813,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const wallet = new Wallet(PRIVATE_KEY, provider);
    *
-   * const transferHandle = await wallet.transfer({
+   * const tx = await wallet.transfer({
    *   to: Wallet.createRandom().address,
    *   amount: ethers.parseEther("0.01"),
    *   paymasterParams: utils.getPaymasterParams(paymaster, {
@@ -774,9 +824,59 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *   }),
    * });
    *
-   * const tx = await transferHandle.wait();
+   * const receipt = await tx.wait();
    *
-   * console.log(`The sum of ${tx.value} ETH was transferred to ${tx.to}`);
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
+   *
+   * @example Transfer token.
+   *
+   * import { Wallet, Provider, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const wallet = new Wallet(PRIVATE_KEY, provider);
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = await wallet.transfer({
+   *   token: tokenL2,
+   *   to: Wallet.createRandom().address,
+   *   amount: ethers.parseEther("0.01"),
+   * });
+   *
+   * const receipt = await tx.wait();
+   *
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
+   *
+   * @example Transfer token using paymaster to facilitate fee payment with an ERC20 token.
+   *
+   * import { Wallet, Provider, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
+   * const token = "0x927488F48ffbc32112F1fF721759649A89721F8F"; // Crown token which can be minted for free
+   * const paymaster = "0x13D0D8550769f59aa241a41897D4859c87f7Dd46"; // Paymaster for Crown token
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const wallet = new Wallet(PRIVATE_KEY, provider);
+   *
+   * const tokenL2 = "0x6a4Fb925583F7D4dF82de62d98107468aE846FD1";
+   * const tx = await wallet.transfer({
+   *   token: tokenL2,
+   *   to: Wallet.createRandom().address,
+   *   amount: ethers.parseEther("0.01"),
+   *   paymasterParams: utils.getPaymasterParams(paymaster, {
+   *     type: "ApprovalBased",
+   *     token: token,
+   *     minimalAllowance: 1,
+   *     innerInput: new Uint8Array(),
+   *   }),
+   * });
+   *
+   * const receipt = await tx.wait();
+   *
+   * console.log(`The sum of ${receipt.value} ETH was transferred to ${receipt.to}`);
    */
   override async transfer(transaction: {
     to: Address;
@@ -793,7 +893,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -964,7 +1064,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -976,7 +1076,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * const populatedTx = await wallet.populateTransaction({
    *   type: utils.EIP712_TX_TYPE,
    *   to: RECEIVER,
-   *   value: 7_000_000_000,
+   *   value: 7_000_000_000n,
    * });
    */
   override async populateTransaction(
@@ -1008,7 +1108,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -1042,7 +1142,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * @example
    *
-   * import { Wallet, Provider, utils } from "zksync-ethers";
+   * import { Wallet, Provider, types, utils } from "zksync-ethers";
    * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -1053,7 +1153,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    *
    * const tx = await wallet.sendTransaction({
    *   to: Wallet.createRandom().address,
-   *   value: 7_000_000,
+   *   value: 7_000_000n,
    *   maxFeePerGas: 3_500_000_000n,
    *   maxPriorityFeePerGas: 2_000_000_000n,
    *   customData: {

--- a/tests/files/tokens.json
+++ b/tests/files/tokens.json
@@ -1,98 +1,26 @@
 [
-    {
-        "name": "DAI",
-        "symbol": "DAI",
-        "decimals": 18,
-        "address": "0x70a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55"
-    },
-    {
-        "name": "wBTC",
-        "symbol": "wBTC",
-        "decimals": 8,
-        "address": "0x1C552d7B40b38Fb1235697Bed7b8e1e47B46e5BA"
-    },
-    {
-        "name": "BAT",
-        "symbol": "BAT",
-        "decimals": 18,
-        "address": "0xdF2Ff03eAAfae59fA7fd30D4f91ab045B3d5D95D"
-    },
-    {
-        "name": "GNT",
-        "symbol": "GNT",
-        "decimals": 18,
-        "address": "0xeF81A0BB8819F94EEf15992F31555a282d7009d1"
-    },
-    {
-        "name": "MLTT",
-        "symbol": "MLTT",
-        "decimals": 18,
-        "address": "0x9ad574a765F65Ec554780c2b5D97979Ed1957d30"
-    },
-    {
-        "name": "DAIK",
-        "symbol": "DAIK",
-        "decimals": 18,
-        "address": "0x266B465D9D37cF6001d38b8e3f839fAE0e10D619"
-    },
-    {
-        "name": "wBTCK",
-        "symbol": "wBTCK",
-        "decimals": 8,
-        "address": "0x05789138d7838a4707FFB45EA5B2c498B1e8Be3c"
-    },
-    {
-        "name": "BATK",
-        "symbol": "BATS",
-        "decimals": 18,
-        "address": "0xfeC8FE20C644fab5d37B86E821A29F1abfEdFc55"
-    },
-    {
-        "name": "GNTK",
-        "symbol": "GNTS",
-        "decimals": 18,
-        "address": "0xde617bf595d8090c63350CA3916b13FBD79f0E0a"
-    },
-    {
-        "name": "MLTTK",
-        "symbol": "MLTTS",
-        "decimals": 18,
-        "address": "0x0B827231D3ECE7906361723170701941f5813191"
-    },
-    {
-        "name": "DAIL",
-        "symbol": "DAIL",
-        "decimals": 18,
-        "address": "0x4EDe5c04d0eF5aDDD222cc7D3C4cbE23Ac7fD4F4"
-    },
-    {
-        "name": "wBTCL",
-        "symbol": "wBTCP",
-        "decimals": 8,
-        "address": "0x2E694B999D7746Dcf3864E9C2F47a4daEBD65721"
-    },
-    {
-        "name": "BATL",
-        "symbol": "BATW",
-        "decimals": 18,
-        "address": "0x0a1D1D084645a46E9E019da345684308701855b6"
-    },
-    {
-        "name": "GNTL",
-        "symbol": "GNTW",
-        "decimals": 18,
-        "address": "0x1630bcE01eb41A9Fd5d49a14e5c6D52b1B127d17"
-    },
-    {
-        "name": "MLTTL",
-        "symbol": "MLTTW",
-        "decimals": 18,
-        "address": "0xa60bc9ae6a6967CAC6D8b08e12a2EF087348Cd32"
-    },
-    {
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
-        "decimals": 18,
-        "address": "0x4A470422bFf67C34a3A565106118023059fa4E34"
-    }
+  {
+    "name": "DAI",
+    "symbol": "DAI",
+    "decimals": 18,
+    "address": "0x70a0F165d6f8054d0d0CF8dFd4DD2005f0AF6B55"
+  },
+  {
+    "name": "wBTC",
+    "symbol": "wBTC",
+    "decimals": 8,
+    "address": "0xAfb5167116e6B833889018916594aC8040DbC05F"
+  },
+  {
+    "name": "BAT",
+    "symbol": "BAT",
+    "decimals": 18,
+    "address": "0x8E9C82509488eD471A83824d20Dd474b8F534a0b"
+  },
+  {
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "decimals": 18,
+    "address": "0x54FCb2405EE4f574C4F09333d25c401E68aD3408"
+  }
 ]

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,17 +7,10 @@ import {
   utils,
 } from '../src';
 import {ethers, Typed} from 'ethers';
-import {IL1Bridge} from '../src/typechain';
-import fs from 'fs';
 
 import TokensL1 from './files/tokens.json';
 import Token from './files/Token.json';
 import Paymaster from './files/Paymaster.json';
-import TokenL2Bridged from './files/TokenL2Bridged.json';
-import TokenL1 from './files/TokenL1.json';
-import CustomBridgeL1 from './files/CustomBridgeL1.json';
-import CustomBridgeL2 from './files/CustomBridgeL2.json';
-import DiamondProxy from './files/diamondProxy.json';
 
 const PRIVATE_KEY =
   '0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110';
@@ -100,76 +93,9 @@ async function createTokenL2(l1TokenAddress: string): Promise<string> {
   return await wallet.l2TokenAddress(l1TokenAddress);
 }
 
-async function deployCustomBridges() {
-  // deploy L2 token
-  const l2TokenFactory = new ContractFactory(
-    TokenL2Bridged.abi,
-    TokenL2Bridged.bytecode,
-    wallet
-  );
-  const l2Token = (await l2TokenFactory.deploy('USDC', 'USDC', 18)) as Contract;
-  await l2Token.waitForDeployment();
-
-  // deploy L1 token
-  const l1TokenFactory = new ethers.ContractFactory(
-    TokenL1.abi,
-    TokenL1.bytecode,
-    wallet._signerL1()
-  );
-  const l1Token = (await l1TokenFactory.deploy('USDC', 'USDC', 18)) as Contract;
-  await l1Token.waitForDeployment();
-
-  // mint token to L1
-  const tx = (await l1Token.mint(
-    wallet.address,
-    ethers.parseEther('100')
-  )) as ethers.ContractTransactionResponse;
-  await tx.wait();
-
-  // deploy custom bridges
-  const gasPrice = (await ethProvider.getFeeData()).gasPrice!;
-  const zkSync = await wallet.getMainContract();
-  const requiredValueToInitializeBridge = await zkSync.l2TransactionBaseCost(
-    gasPrice,
-    10_000_000,
-    utils.REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT
-  );
-  const l1BridgeFactory = new ethers.ContractFactory(
-    CustomBridgeL1.abi,
-    CustomBridgeL1.bytecode,
-    wallet._signerL1()
-  );
-  const l1Bridge = (await l1BridgeFactory.deploy(
-    [CustomBridgeL2.bytecode],
-    [
-      await l1Token.getAddress(),
-      await l2Token.getAddress(),
-      DiamondProxy.address,
-    ],
-    requiredValueToInitializeBridge,
-    {
-      gasPrice,
-      value: requiredValueToInitializeBridge,
-      gasLimit: 10_000_000,
-    }
-  )) as IL1Bridge;
-  await l1Bridge.waitForDeployment();
-
-  // connect L2 token to L2 custom bridge
-  await l2Token.setBridge(await l1Bridge.l2Bridge());
-
-  return {
-    l1Token: await l1Token.getAddress(),
-    l2Token: await l2Token.getAddress(),
-    l1Bridge: await l1Bridge.getAddress(),
-    l2Bridge: await l1Bridge.l2Bridge(),
-  };
-}
-
 /*
 Deploy token to the L2 network through deposit transaction.
 Deploy approval token and it's paymaster.
-Deploy custom bridges for custom token.
  */
 async function main() {
   console.log('===== Depositing DAI to L2 =====');
@@ -182,21 +108,6 @@ async function main() {
   console.log(`Paymaster: ${paymaster}`);
   console.log(`Paymaster ETH balance: ${await provider.getBalance(paymaster)}`);
   console.log(`Wallet Crown balance: ${await wallet.getBalance(token)}`);
-
-  console.log('===== Deploying custom bridges =====');
-  const customAddresses = await deployCustomBridges();
-  const {l1Token, l2Token, l1Bridge, l2Bridge} = customAddresses;
-  console.log(`L1 USDC address: ${l1Token}`);
-  console.log(`L2 USDC address: ${l2Token}`);
-  console.log(`L1 custom bridge address: ${l1Bridge}`);
-  console.log(`L2 custom bridge address: ${l2Bridge}`);
-  console.log(`L1 USDC balance: ${await wallet.getBalanceL1(l1Token)}`);
-  console.log(`L2 USDC balance: ${await wallet.getBalance(l2Token)}`);
-
-  fs.writeFileSync(
-    'tests/files/customBridge.json',
-    utils.toJSON(customAddresses)
-  );
 }
 
 main()


### PR DESCRIPTION
# What :computer: 
* Export `typechain` folder at the top of the package.
* Make `Signer` compatible when created using `BrowserProvider.getSigner()`.