### PR TITLE
Ethers V6: Fix types and provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "scripts": {
     "test:build": "rm -rf tests/build && tsc -p tsconfig.test.json",
-    "test:prepare-proxy": "cd scripts && ./update-diamond-proxy.sh && cd ../",
     "test:prepare": "ts-node tests/setup.ts",
     "test:coverage": "c8 -c .nycrc mocha -r ts-node/register tests/**/*.test.ts",
     "test:wait": "ts-node tests/wait.ts",

--- a/scripts/update-diamond-proxy.sh
+++ b/scripts/update-diamond-proxy.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-output=$(docker exec local-setup_zksync_1 cat /deployed_contracts.log)
-address=$(echo "$output" | grep CONTRACTS_DIAMOND_PROXY_ADDR | cut -d'=' -f2 | tr -d '[:space:]')
-echo "{\"address\": \"$address\"}" > ../tests/files/diamondProxy.json

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1354,7 +1354,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
       const hash = ethers.hexlify(withdrawalHash);
       const receipt = await this._providerL2().getTransactionReceipt(hash);
       if (!receipt) {
-        throw new Error("Transaction is not mined!")
+        throw new Error('Transaction is not mined!');
       }
       const log = receipt.logs.filter(
         log =>
@@ -1372,7 +1372,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
       const hash = ethers.hexlify(withdrawalHash);
       const receipt = await this._providerL2().getTransactionReceipt(hash);
       if (!receipt) {
-        throw new Error("Transaction is not mined!")
+        throw new Error('Transaction is not mined!');
       }
       const messages = Array.from(receipt.l2ToL1Logs.entries()).filter(
         ([, log]) => isAddressEq(log.sender, L1_MESSENGER_ADDRESS)
@@ -1529,7 +1529,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
         ethers.hexlify(depositHash)
       );
       if (!receipt) {
-        throw new Error("Transaction is not mined!")
+        throw new Error('Transaction is not mined!');
       }
       const successL2ToL1LogIndex = receipt.l2ToL1Logs.findIndex(
         l2ToL1log =>

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1353,6 +1353,9 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
     async _getWithdrawalLog(withdrawalHash: BytesLike, index = 0) {
       const hash = ethers.hexlify(withdrawalHash);
       const receipt = await this._providerL2().getTransactionReceipt(hash);
+      if (!receipt) {
+        throw new Error("Transaction is not mined!")
+      }
       const log = receipt.logs.filter(
         log =>
           isAddressEq(log.address, L1_MESSENGER_ADDRESS) &&
@@ -1368,6 +1371,9 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
     async _getWithdrawalL2ToL1Log(withdrawalHash: BytesLike, index = 0) {
       const hash = ethers.hexlify(withdrawalHash);
       const receipt = await this._providerL2().getTransactionReceipt(hash);
+      if (!receipt) {
+        throw new Error("Transaction is not mined!")
+      }
       const messages = Array.from(receipt.l2ToL1Logs.entries()).filter(
         ([, log]) => isAddressEq(log.sender, L1_MESSENGER_ADDRESS)
       );
@@ -1522,6 +1528,9 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
       const receipt = await this._providerL2().getTransactionReceipt(
         ethers.hexlify(depositHash)
       );
+      if (!receipt) {
+        throw new Error("Transaction is not mined!")
+      }
       const successL2ToL1LogIndex = receipt.l2ToL1Logs.findIndex(
         l2ToL1log =>
           isAddressEq(l2ToL1log.sender, BOOTLOADER_FORMAL_ADDRESS) &&

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -8,7 +8,6 @@ import {
   ethers,
   Interface,
   InterfaceAbi,
-  TransactionReceipt,
 } from 'ethers';
 import {
   CONTRACT_DEPLOYER,
@@ -224,8 +223,9 @@ export class ContractFactory<
       contract.deploymentTransaction()!.hash
     );
 
-    const deployedAddresses = getDeployedContracts(deployTxReceipt!)
-      .map(info => info.deployedAddress);
+    const deployedAddresses = getDeployedContracts(deployTxReceipt!).map(
+      info => info.deployedAddress
+    );
 
     const contractWithCorrectAddress = new ethers.Contract(
       deployedAddresses[deployedAddresses.length - 1],
@@ -235,7 +235,8 @@ export class ContractFactory<
       deploymentTransaction(): ContractTransactionResponse;
     } & Omit<I, keyof BaseContract>;
 
-    contractWithCorrectAddress.deploymentTransaction = () => contract.deploymentTransaction()!;
+    contractWithCorrectAddress.deploymentTransaction = () =>
+      contract.deploymentTransaction()!;
     return contractWithCorrectAddress;
   }
 }

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -218,15 +218,14 @@ export class ContractFactory<
       deploymentTransaction(): ContractTransactionResponse;
     } & Omit<I, keyof BaseContract>
   > {
-    const contract = await super.deploy(...args);
+    const contract = await (await super.deploy(...args)).waitForDeployment();
 
     const deployTxReceipt = await this.runner?.provider?.getTransactionReceipt(
-      (contract.deploymentTransaction() as ContractTransactionResponse).hash
+      contract.deploymentTransaction()!.hash
     );
 
-    const deployedAddresses = getDeployedContracts(
-      deployTxReceipt as TransactionReceipt
-    ).map(info => info.deployedAddress);
+    const deployedAddresses = getDeployedContracts(deployTxReceipt!)
+      .map(info => info.deployedAddress);
 
     const contractWithCorrectAddress = new ethers.Contract(
       deployedAddresses[deployedAddresses.length - 1],
@@ -236,8 +235,7 @@ export class ContractFactory<
       deploymentTransaction(): ContractTransactionResponse;
     } & Omit<I, keyof BaseContract>;
 
-    contractWithCorrectAddress.deploymentTransaction = () =>
-      contract.deploymentTransaction() as ContractTransactionResponse;
+    contractWithCorrectAddress.deploymentTransaction = () => contract.deploymentTransaction()!;
     return contractWithCorrectAddress;
   }
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -137,7 +137,9 @@ export function JsonRpcApiProvider<
     override async getTransactionReceipt(
       txHash: string
     ): Promise<TransactionReceipt | null> {
-      return await super.getTransactionReceipt(txHash) as TransactionReceipt | null;
+      return (await super.getTransactionReceipt(
+        txHash
+      )) as TransactionReceipt | null;
     }
 
     /**
@@ -149,7 +151,7 @@ export function JsonRpcApiProvider<
     override async getTransaction(
       txHash: string
     ): Promise<TransactionResponse> {
-      return await super.getTransaction(txHash) as TransactionResponse;
+      return (await super.getTransaction(txHash)) as TransactionResponse;
     }
 
     /**
@@ -911,7 +913,7 @@ export function JsonRpcApiProvider<
       const hash = ethers.hexlify(txHash);
       const receipt = await this.getTransactionReceipt(hash);
       if (!receipt) {
-        throw new Error("Transaction is not mined!")
+        throw new Error('Transaction is not mined!');
       }
       const messages = Array.from(receipt.l2ToL1Logs.entries()).filter(
         ([, log]) => isAddressEq(log.sender, BOOTLOADER_FORMAL_ADDRESS)

--- a/src/smart-account-utils.ts
+++ b/src/smart-account-utils.ts
@@ -127,9 +127,7 @@ export const signPayloadWithMultipleECDSA: PayloadSigner = async (
   secret: string[] | SigningKey[]
 ) => {
   if (!Array.isArray(secret) || secret.length < 2) {
-    throw new Error(
-      'Multiple keys are required for multisig transaction signing!'
-    );
+    throw new Error('Multiple keys are required for multisig signing!');
   }
 
   const signatures = secret.map(
@@ -259,6 +257,6 @@ export const populateTransactionMultisigECDSA: TransactionBuilder = async (
   if (!Array.isArray(secret) || secret.length < 2) {
     throw new Error('Multiple keys are required to build the transaction!');
   }
-  // populatesTransaction estimates gas which accepts only one address, so the first signer is chosen.
+  // estimates gas accepts only one address, so the first signer is chosen.
   return populateTransactionECDSA(tx, secret[0], provider);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -658,17 +658,17 @@ export interface TransactionDetails {
 /** Represents the full deposit fee containing fees for both L1 and L2 transactions. */
 export interface FullDepositFee {
   /** The maximum fee per gas for L1 transaction. */
-  maxFeePerGas?: BigInt;
+  maxFeePerGas?: bigint;
   /** The maximum priority fee per gas for L1 transaction. */
-  maxPriorityFeePerGas?: BigInt;
+  maxPriorityFeePerGas?: bigint;
   /** The gas price for L2 transaction. */
-  gasPrice?: BigInt;
+  gasPrice?: bigint;
   /** The base cost of the deposit transaction on L2. */
-  baseCost: BigInt;
+  baseCost: bigint;
   /** The gas limit for L1 transaction. */
-  l1GasLimit: BigInt;
+  l1GasLimit: bigint;
   /** The gas limit for L2 transaction. */
-  l2GasLimit: BigInt;
+  l2GasLimit: bigint;
 }
 
 /** Represents a raw block transaction. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,8 @@ import {
   assert,
   assertArgument,
   BigNumberish,
-  BytesLike, defineProperties,
+  BytesLike,
+  defineProperties,
   ethers,
   Signature as EthersSignature,
   TransactionRequest as EthersTransactionRequest,
@@ -145,7 +146,7 @@ export class TransactionResponse extends ethers.TransactionResponse {
     super(params, provider);
     defineProperties<TransactionResponse>(this, {
       l1BatchNumber: params.l1BatchNumber,
-      l1BatchTxIndex: params.l1BatchTxIndex
+      l1BatchTxIndex: params.l1BatchTxIndex,
     });
   }
 
@@ -170,7 +171,7 @@ export class TransactionResponse extends ethers.TransactionResponse {
   }
 
   override async getTransaction(): Promise<TransactionResponse> {
-    return await super.getTransaction() as TransactionResponse;
+    return (await super.getTransaction()) as TransactionResponse;
   }
 
   override replaceableTransaction(startBlock: number): TransactionResponse {
@@ -181,7 +182,7 @@ export class TransactionResponse extends ethers.TransactionResponse {
   }
 
   override async getBlock(): Promise<Block> {
-    return await super.getBlock() as Block;
+    return (await super.getBlock()) as Block;
   }
 
   /** Waits for transaction to be finalized. */
@@ -276,15 +277,17 @@ export class Block extends ethers.Block {
 
   constructor(params: any, provider: ethers.Provider) {
     super(params, provider);
-    this.#transactions = params.transactions.map((tx: TransactionResponse | string) => {
-      if (typeof(tx) !== "string") {
-        return new TransactionResponse(tx, provider);
+    this.#transactions = params.transactions.map(
+      (tx: TransactionResponse | string) => {
+        if (typeof tx !== 'string') {
+          return new TransactionResponse(tx, provider);
+        }
+        return tx;
       }
-      return tx;
-    });
+    );
     defineProperties<Block>(this, {
-      l1BatchNumber:  params.l1BatchNumber,
-      l1BatchTimestamp:  params.l1BatchTimestamp
+      l1BatchNumber: params.l1BatchNumber,
+      l1BatchTimestamp: params.l1BatchTimestamp,
     });
   }
 
@@ -301,12 +304,19 @@ export class Block extends ethers.Block {
     const txs = this.#transactions.slice();
 
     // Doesn't matter...
-    if (txs.length === 0) { return [ ]; }
+    if (txs.length === 0) {
+      return [];
+    }
 
     // Make sure we prefetched the transactions
-    assert(typeof(txs[0]) === "object", "transactions were not prefetched with block request", "UNSUPPORTED_OPERATION", {
-      operation: "transactionResponses()"
-    });
+    assert(
+      typeof txs[0] === 'object',
+      'transactions were not prefetched with block request',
+      'UNSUPPORTED_OPERATION',
+      {
+        operation: 'transactionResponses()',
+      }
+    );
 
     return txs as TransactionResponse[];
   }
@@ -316,27 +326,32 @@ export class Block extends ethers.Block {
   ): Promise<TransactionResponse> {
     // Find the internal value by its index or hash
     let tx: string | TransactionResponse | undefined = undefined;
-    if (typeof(indexOrHash) === "number") {
+    if (typeof indexOrHash === 'number') {
       tx = this.#transactions[indexOrHash];
-
     } else {
       const hash = indexOrHash.toLowerCase();
       for (const v of this.#transactions) {
-        if (typeof(v) === "string") {
-          if (v !== hash) { continue; }
+        if (typeof v === 'string') {
+          if (v !== hash) {
+            continue;
+          }
           tx = v;
           break;
         } else {
-          if (v.hash === hash) { continue; }
+          if (v.hash === hash) {
+            continue;
+          }
           tx = v;
           break;
         }
       }
     }
-    if (tx == null) { throw new Error("no such tx"); }
+    if (!tx) {
+      throw new Error('no such tx');
+    }
 
-    if (typeof(tx) === "string") {
-      return <TransactionResponse>(await this.provider.getTransaction(tx));
+    if (typeof tx === 'string') {
+      return <TransactionResponse>await this.provider.getTransaction(tx);
     } else {
       return tx;
     }
@@ -368,15 +383,15 @@ export class Log extends ethers.Log {
   }
 
   override async getBlock(): Promise<Block> {
-    return await super.getBlock() as Block;
+    return (await super.getBlock()) as Block;
   }
 
   override async getTransaction(): Promise<TransactionResponse> {
-    return await super.getTransaction() as TransactionResponse;
+    return (await super.getTransaction()) as TransactionResponse;
   }
 
   override async getTransactionReceipt(): Promise<TransactionReceipt> {
-    return await super.getTransactionReceipt() as TransactionReceipt;
+    return (await super.getTransactionReceipt()) as TransactionReceipt;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -729,7 +729,7 @@ export interface StorageProof {
 /**
  *  Signs various types of payloads, optionally using a some kind of secret.
  *
- *  @param payload The payload that needs to be sign already populated transaction to sign.
+ *  @param payload The payload that needs to be sign.
  *  @param [secret] The secret used for signing the `payload`.
  *  @param [provider] The provider is used to fetch data from the network if it is required for signing.
  *  @returns A promise that resolves to the serialized signature in hexadecimal format.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -302,7 +302,7 @@ export function getHashedL2ToL1Msg(
   const encodedMsg = new Uint8Array([
     0, // l2ShardId
     1, // isService
-    ...ethers.getBytes(ethers.zeroPadValue(ethers.toBeHex(txNumberInBlock), 2)),
+    ...ethers.getBytes(ethers.toBeHex(txNumberInBlock, 2)),
     ...ethers.getBytes(L1_MESSENGER_ADDRESS),
     ...ethers.getBytes(ethers.zeroPadValue(sender, 32)),
     ...ethers.getBytes(ethers.keccak256(msg)),
@@ -408,7 +408,7 @@ export function createAddress(
       ethers.concat([
         prefix,
         ethers.zeroPadValue(sender, 32),
-        ethers.zeroPadValue(ethers.toBeHex(senderNonce), 32),
+        ethers.toBeHex(senderNonce, 32),
       ])
     )
     .slice(26);
@@ -827,10 +827,8 @@ const ADDRESS_MODULO = 2n ** 160n;
  *
  */
 export function applyL1ToL2Alias(address: string): string {
-  return ethers.zeroPadValue(
-    ethers.toBeHex(
-      (BigInt(address) + BigInt(L1_TO_L2_ALIAS_OFFSET)) % ADDRESS_MODULO
-    ),
+  return ethers.toBeHex(
+      (BigInt(address) + BigInt(L1_TO_L2_ALIAS_OFFSET)) % ADDRESS_MODULO,
     20
   );
 }
@@ -854,7 +852,7 @@ export function undoL1ToL2Alias(address: string): string {
   if (result < 0n) {
     result += ADDRESS_MODULO;
   }
-  return ethers.zeroPadValue(ethers.toBeHex(result), 20);
+  return ethers.toBeHex(result, 20);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -619,16 +619,16 @@ export function hashBytecode(bytecode: ethers.BytesLike): Uint8Array {
  * tx: types.TransactionLike = {
  *   type: 113,
  *   nonce: 0,
- *   maxPriorityFeePerGas: BigInt(0),
- *   maxFeePerGas: BigInt(0),
- *   gasLimit: BigInt(0),
+ *   maxPriorityFeePerGas: 0n,
+ *   maxFeePerGas: 0n,
+ *   gasLimit: 0n,
  *   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
- *   value: BigInt(1000000),
+ *   value: 1000000n,
  *   data: "0x",
- *   chainId: BigInt(270),
+ *   chainId: 270n,
  *   from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
  *   customData: {
- *     gasPerPubdata: BigInt(50000),
+ *     gasPerPubdata: 50000n,
  *     factoryDeps: [],
  *     customSignature: "0x",
  *     paymasterParams: null,
@@ -1089,7 +1089,7 @@ export async function isMessageSignatureCorrect(
  *   chainId: 270,
  *   from: ADDRESS,
  *   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
- *   value: BigInt(7_000_000),
+ *   value: 7_000_000n,
  * };
  *
  * const eip712Signer = new EIP712Signer(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -828,7 +828,7 @@ const ADDRESS_MODULO = 2n ** 160n;
  */
 export function applyL1ToL2Alias(address: string): string {
   return ethers.toBeHex(
-      (BigInt(address) + BigInt(L1_TO_L2_ALIAS_OFFSET)) % ADDRESS_MODULO,
+    (BigInt(address) + BigInt(L1_TO_L2_ALIAS_OFFSET)) % ADDRESS_MODULO,
     20
   );
 }

--- a/tests/integration/signer.test.ts
+++ b/tests/integration/signer.test.ts
@@ -911,11 +911,11 @@ describe('L1VoidSigner', async () => {
           token: utils.LEGACY_ETH_ADDRESS,
           to: await signer.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should throw an error when there is not enough allowance to cover the deposit', async () => {
@@ -956,11 +956,11 @@ describe('L1VoidSigner', async () => {
           token: DAI_L1,
           to: await signer.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should throw an error when there is not enough balance for the deposit', async () => {
@@ -1013,11 +1013,11 @@ describe('L1VoidSigner', async () => {
           token: token,
           to: await signer.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should return fee for base token deposit', async () => {
@@ -1061,11 +1061,11 @@ describe('L1VoidSigner', async () => {
           token: token,
           to: await signer.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should throw an error when there is not enough token allowance to cover the deposit', async () => {

--- a/tests/integration/types.test.ts
+++ b/tests/integration/types.test.ts
@@ -52,8 +52,7 @@ describe('types', () => {
         to: ADDRESS2,
         amount: 1_000_000,
       });
-      await tx.wait();
-      receipt = await provider.getTransactionReceipt(tx.hash);
+      receipt = await tx.wait();
     });
 
     describe('#getTransaction()', () => {
@@ -88,8 +87,7 @@ describe('types', () => {
         to: ADDRESS2,
         amount: 1_000_000,
       });
-      await tx.wait();
-      const receipt = await provider.getTransactionReceipt(tx.hash);
+      const receipt = await tx.wait();
       block = await provider.getBlock(receipt.blockHash, true);
     });
 
@@ -132,8 +130,7 @@ describe('types', () => {
         to: ADDRESS2,
         amount: 1_000_000,
       });
-      await tx.wait();
-      const receipt = await provider.getTransactionReceipt(tx.hash);
+      const receipt = await tx.wait();
       log = new types.Log(
         {
           blockHash: receipt.blockHash,

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -870,7 +870,7 @@ describe('Wallet', () => {
           .true;
         expect(l1BalanceBeforeDeposit - l1BalanceAfterDeposit >= amount).to.be
           .true;
-      }).timeout(30_000);
+      }).timeout(60_000);
     } else {
       it('should deposit ETH to L2 network', async () => {
         const amount = 7_000_000_000;

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1022,11 +1022,11 @@ describe('Wallet', () => {
           token: utils.LEGACY_ETH_ADDRESS,
           to: await wallet.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       });
 
       it('should throw an error when there is not enough allowance to cover the deposit', async () => {
@@ -1050,11 +1050,11 @@ describe('Wallet', () => {
           token: DAI_L1,
           to: await wallet.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should throw an error when there is not enough balance for the deposit', async () => {
@@ -1107,11 +1107,11 @@ describe('Wallet', () => {
           token: token,
           to: await wallet.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should return fee for base token deposit', async () => {
@@ -1153,11 +1153,11 @@ describe('Wallet', () => {
           token: token,
           to: await wallet.getAddress(),
         });
-        expect(result.baseCost.valueOf() > 0n).to.be.true;
-        expect(result.l1GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.l2GasLimit.valueOf() > 0n).to.be.true;
-        expect(result.maxPriorityFeePerGas!.valueOf() > 0n).to.be.true;
-        expect(result.maxFeePerGas!.valueOf() > 0n).to.be.true;
+        expect(result.baseCost > 0n).to.be.true;
+        expect(result.l1GasLimit > 0n).to.be.true;
+        expect(result.l2GasLimit > 0n).to.be.true;
+        expect(result.maxPriorityFeePerGas! > 0n).to.be.true;
+        expect(result.maxFeePerGas! > 0n).to.be.true;
       }).timeout(10_000);
 
       it('should throw an error when there is not enough token allowance to cover the deposit', async () => {


### PR DESCRIPTION
# What :computer: 
* `FullDepositFee` uses `bigint` instead of `BigInt`.
* `Provider.getTransactionReceipt()` now returns `null` it transaction is not mined, not found or discarded.
* `Block.l1BatchTimestamp` now contains accurate value.