### PR TITLE
build: support esm module

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 build/
+build-esm/
 typechain/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+build-esm
 node_modules
 coverage
 docs

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,4 +6,5 @@ CHANGELOG.md
 typechain
 abi
 build
+build-esm
 tests/files

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "zksync-ethers",
   "version": "6.7.1",
   "main": "build/index.js",
+  "module": "build-esm/index.js",
   "types": "build/index.d.ts",
   "description": "A Web3 library for interacting with the ZkSync Layer 2 scaling solution.",
   "author": {
@@ -29,6 +30,7 @@
   },
   "files": [
     "build/",
+    "build-esm/",
     "abi/",
     "src/",
     "typechain"
@@ -61,7 +63,7 @@
     "test:coverage": "c8 -c .nycrc mocha -r ts-node/register tests/**/*.test.ts",
     "test:wait": "ts-node tests/wait.ts",
     "test": "mocha -r ts-node/register tests/**/*.test.ts",
-    "build": "tsc",
+    "build": "tsc & tsc --module ESNEXT --moduleResolution Node --outDir build-esm",
     "lint": "gts lint",
     "lint:fix": "gts fix",
     "watch": "tsc --watch",


### PR DESCRIPTION
# What :computer: 
* build ESM module assets into `/build-esm` folder during the building process
* add `build-esm/index.js` to the "module" filed of package.json
* add `build-esm` folder into `.gitignore`

# Why :hand:
* When calling `import {..} from "zksync-ethers"`, the `zksync-ethers` package will export an ESM module instead of a CommonJS module.
* ESM modules benefit from tree shaking, which can result in smaller and more optimized bundles.
* The `ethers` package exports both ESM and CommonJS modules; `zksync-ethers` could follow the same pattern

# Evidence :camera:
<img width="559" alt="image" src="https://github.com/zksync-sdk/zksync-ethers/assets/94817349/7862cff8-67ae-487e-b58c-e6012f08c9ed">
