### PR TITLE
Ethers V6: test: use `utils.L2_BASE_TOKEN_ADDRESS` as a address when working with base token

### DIFF
--- a/tests/integration/smart-account.test.ts
+++ b/tests/integration/smart-account.test.ts
@@ -762,7 +762,7 @@ describe('SmartAccount', async () => {
         const amount = 7_000_000_000n;
         const l2BalanceBeforeWithdrawal = await account.getBalance();
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await account.getAddress(),
           amount: amount,
         });
@@ -795,7 +795,7 @@ describe('SmartAccount', async () => {
           await account.getBalance(APPROVAL_TOKEN);
 
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await account.getAddress(),
           amount: amount,
           paymasterParams: utils.getPaymasterParams(PAYMASTER, {
@@ -1562,7 +1562,7 @@ describe('MultisigECDSASmartAccount', async () => {
         const amount = 7_000_000_000n;
         const l2BalanceBeforeWithdrawal = await account.getBalance();
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(), // send to L1 EOA since AA does not exit on L1
           amount: amount,
         });
@@ -1595,7 +1595,7 @@ describe('MultisigECDSASmartAccount', async () => {
           await account.getBalance(APPROVAL_TOKEN);
 
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(), // send to L1 EOA since AA does not exit on L1
           amount: amount,
           paymasterParams: utils.getPaymasterParams(PAYMASTER, {

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1407,7 +1407,7 @@ describe('Wallet', () => {
         const amount = 7_000_000_000n;
         const l2BalanceBeforeWithdrawal = await wallet.getBalance();
         const withdrawTx = await wallet.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(),
           amount: amount,
         });
@@ -1440,7 +1440,7 @@ describe('Wallet', () => {
           await wallet.getBalance(APPROVAL_TOKEN);
 
         const withdrawTx = await wallet.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(),
           amount: amount,
           paymasterParams: utils.getPaymasterParams(PAYMASTER, {
@@ -1900,7 +1900,7 @@ describe('Wallet', () => {
         const amount = 7_000_000_000n;
         const balanceBeforeTransfer = await provider.getBalance(ADDRESS2);
         const tx = await wallet.transfer({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: ADDRESS2,
           amount: amount,
         });


### PR DESCRIPTION
# What :computer: 
* Use `utils.L2_BASE_TOKEN_ADDRESS` as a address when working with base token.