### PR TITLE
Ethers V5: test: use `utils.L2_BASE_TOKEN_ADDRESS` as a address when working with base token

### DIFF
--- a/tests/integration/smart-account.test.ts
+++ b/tests/integration/smart-account.test.ts
@@ -780,7 +780,7 @@ describe('SmartAccount', async () => {
         const amount = 7_000_000_000;
         const l2BalanceBeforeWithdrawal = await account.getBalance();
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await account.getAddress(),
           amount: amount,
         });
@@ -814,7 +814,7 @@ describe('SmartAccount', async () => {
           await account.getBalance(APPROVAL_TOKEN);
 
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await account.getAddress(),
           amount: amount,
           paymasterParams: utils.getPaymasterParams(PAYMASTER, {
@@ -1613,7 +1613,7 @@ describe('MultisigECDSASmartAccount', async () => {
         const amount = 7_000_000_000;
         const l2BalanceBeforeWithdrawal = await account.getBalance();
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(), // send to L1 EOA since AA does not exit on L1
           amount: amount,
         });
@@ -1647,7 +1647,7 @@ describe('MultisigECDSASmartAccount', async () => {
           await account.getBalance(APPROVAL_TOKEN);
 
         const withdrawTx = await account.withdraw({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(), // send to L1 EOA since AA does not exit on L1
           amount: amount,
           paymasterParams: utils.getPaymasterParams(PAYMASTER, {

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1293,12 +1293,11 @@ describe('Wallet', () => {
 
       it('should withdraw base token to L1 network', async () => {
         const amount = 7_000_000_000;
-        const baseToken = await wallet.getBaseToken();
 
         const l2BalanceBeforeWithdrawal = await wallet.getBalance();
 
         const withdrawTx = await wallet.withdraw({
-          token: baseToken,
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: await wallet.getAddress(),
           amount: amount,
         });
@@ -1739,7 +1738,7 @@ describe('Wallet', () => {
         const amount = 7_000_000_000;
         const balanceBeforeTransfer = await provider.getBalance(ADDRESS2);
         const tx = await wallet.transfer({
-          token: await wallet.getBaseToken(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: ADDRESS2,
           amount: amount,
         });


### PR DESCRIPTION
# What :computer: 
* Use `utils.L2_BASE_TOKEN_ADDRESS` as a address when working with base token.