### PR TITLE
Ethers V6: refactor(provider): use `utils.L2_BASE_TOKEN_ADDRESS` as a address when working with base token

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -1478,7 +1478,6 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
         withdrawalHash,
         index
       );
-      const sender = ethers.dataSlice(log.topics[1], 12);
       // `getLogProof` is called not to get proof but
       // to get the index of the corresponding L2->L1 log,
       // which is returned as `proof.id`.
@@ -1491,18 +1490,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
       }
 
       const chainId = (await this._providerL2().getNetwork()).chainId;
-
-      let l1Bridge: IL1SharedBridge;
-
-      if (await this._providerL2().isBaseToken(sender)) {
-        l1Bridge = (await this.getL1BridgeContracts()).shared;
-      } else {
-        const l2Bridge = IL2Bridge__factory.connect(sender, this._providerL2());
-        l1Bridge = IL1SharedBridge__factory.connect(
-          await l2Bridge.l1Bridge(),
-          this._providerL1()
-        );
-      }
+      const l1Bridge = (await this.getL1BridgeContracts()).shared;
 
       return await l1Bridge.isWithdrawalFinalized(
         chainId,

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -461,7 +461,7 @@ describe('Provider', () => {
           data: '0x51cff8d900000000000000000000000036615cf349d7f6344891b1e7ca7c72883f5dc049',
         };
         const result = await provider.getWithdrawTx({
-          token: await provider.getBaseTokenContractAddress(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           amount: 7_000_000_000,
           to: ADDRESS1,
           from: ADDRESS1,
@@ -484,7 +484,7 @@ describe('Provider', () => {
           },
         };
         const result = await provider.getWithdrawTx({
-          token: await provider.getBaseTokenContractAddress(),
+          token: utils.L2_BASE_TOKEN_ADDRESS,
           amount: 7_000_000_000,
           to: ADDRESS1,
           from: ADDRESS1,

--- a/tests/integration/smart-account.test.ts
+++ b/tests/integration/smart-account.test.ts
@@ -588,7 +588,7 @@ describe('SmartAccount', async () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -627,7 +627,7 @@ describe('SmartAccount', async () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -678,7 +678,7 @@ describe('SmartAccount', async () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -720,7 +720,7 @@ describe('SmartAccount', async () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -767,7 +767,7 @@ describe('SmartAccount', async () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -806,7 +806,7 @@ describe('SmartAccount', async () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -857,7 +857,7 @@ describe('SmartAccount', async () => {
         amount: amount,
       });
       await withdrawTx.waitFinalize();
-      // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
       const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
         withdrawTx.hash
@@ -904,7 +904,7 @@ describe('SmartAccount', async () => {
         }),
       });
       await withdrawTx.waitFinalize();
-      // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
       const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
         withdrawTx.hash
@@ -1388,7 +1388,7 @@ describe('MultisigECDSASmartAccount', async () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1427,7 +1427,7 @@ describe('MultisigECDSASmartAccount', async () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1478,7 +1478,7 @@ describe('MultisigECDSASmartAccount', async () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1520,7 +1520,7 @@ describe('MultisigECDSASmartAccount', async () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1567,7 +1567,7 @@ describe('MultisigECDSASmartAccount', async () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1606,7 +1606,7 @@ describe('MultisigECDSASmartAccount', async () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1657,7 +1657,7 @@ describe('MultisigECDSASmartAccount', async () => {
         amount: amount,
       });
       await withdrawTx.waitFinalize();
-      // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
       const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
         withdrawTx.hash
@@ -1705,7 +1705,7 @@ describe('MultisigECDSASmartAccount', async () => {
         }),
       });
       await withdrawTx.waitFinalize();
-      // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
       const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
         withdrawTx.hash

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1234,7 +1234,7 @@ describe('Wallet', () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1273,7 +1273,7 @@ describe('Wallet', () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1323,7 +1323,7 @@ describe('Wallet', () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1365,7 +1365,7 @@ describe('Wallet', () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1412,7 +1412,7 @@ describe('Wallet', () => {
           amount: amount,
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1451,7 +1451,7 @@ describe('Wallet', () => {
           }),
         });
         await withdrawTx.waitFinalize();
-        // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
         const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
           withdrawTx.hash
@@ -1502,7 +1502,7 @@ describe('Wallet', () => {
         amount: amount,
       });
       await withdrawTx.waitFinalize();
-      // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
       const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
         withdrawTx.hash
@@ -1549,7 +1549,7 @@ describe('Wallet', () => {
         }),
       });
       await withdrawTx.waitFinalize();
-      // expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
 
       const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
         withdrawTx.hash
@@ -1900,7 +1900,6 @@ describe('Wallet', () => {
         const amount = 7_000_000_000n;
         const balanceBeforeTransfer = await provider.getBalance(ADDRESS2);
         const tx = await wallet.transfer({
-          token: utils.L2_BASE_TOKEN_ADDRESS,
           to: ADDRESS2,
           amount: amount,
         });


### PR DESCRIPTION
# What :computer: 
* Use `utils.L2_BASE_TOKEN_ADDRESS` as a address when working with base token.