### PR TITLE
Ethers V6:  Add new rpc endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   "scripts": {
     "test:build": "rm -rf tests/build && tsc -p tsconfig.test.json",
     "test:prepare": "ts-node tests/setup.ts",
-    "test:coverage": "c8 -c .nycrc mocha -r ts-node/register --timeout 10000 tests/**/*.test.ts",
+    "test:coverage": "c8 -c .nycrc mocha -r ts-node/register --timeout 20000 tests/**/*.test.ts",
     "test:wait": "ts-node tests/wait.ts",
-    "test": "mocha -r ts-node/register --timeout 10000 tests/**/*.test.ts",
+    "test": "mocha -r ts-node/register --timeout 20000 tests/**/*.test.ts",
     "build": "tsc & tsc --module ESNEXT --moduleResolution Node --outDir build-esm",
     "lint": "gts lint",
     "lint:fix": "gts fix",

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -90,7 +90,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
     }
 
     /**
-     * Returns `Contract` wrapper of the zkSync Era smart contract.
+     * Returns `Contract` wrapper of the ZKsync Era smart contract.
      */
     async getMainContract(): Promise<IZkSyncHyperchain> {
       const address = await this._providerL2().getMainContractAddress();
@@ -176,7 +176,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
      *
      * @param token The Ethereum address of the token.
      * @param [bridgeAddress] The address of the bridge contract to be used.
-     * Defaults to the default zkSync Era bridge, either `L1EthBridge` or `L1Erc20Bridge`.
+     * Defaults to the default ZKsync Era bridge, either `L1EthBridge` or `L1Erc20Bridge`.
      * @param [blockTag] The block in which an allowance should be checked.
      * Defaults to 'committed', i.e., the latest processed block.
      */
@@ -204,7 +204,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
      * Returns the L2 token address equivalent for a L1 token address as they are not necessarily equal.
      * The ETH address is set to the zero address.
      *
-     * @remarks Only works for tokens bridged on default zkSync Era bridges.
+     * @remarks Only works for tokens bridged on default ZKsync Era bridges.
      *
      * @param token The address of the token on L1.
      */
@@ -213,7 +213,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
     }
 
     /**
-     * Bridging ERC20 tokens from L1 requires approving the tokens to the zkSync Era smart contract.
+     * Bridging ERC20 tokens from L1 requires approving the tokens to the ZKsync Era smart contract.
      *
      * @param token The L1 address of the token.
      * @param amount The amount of the token to be approved.
@@ -355,7 +355,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
      * explicitly stated in the overrides, this field will be equal to the tip the operator will receive on top of
      * the base cost of the transaction.
      * @param [transaction.bridgeAddress] The address of the bridge contract to be used.
-     * Defaults to the default zkSync Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
+     * Defaults to the default ZKsync Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
      * @param [transaction.approveERC20] Whether or not token approval should be performed under the hood.
      * Set this flag to true if you bridge an ERC20 token and didn't call the {@link approveERC20} function beforehand.
      * @param [transaction.approveBaseERC20] Whether or not base token approval should be performed under the hood.
@@ -700,7 +700,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
      * explicitly stated in the overrides, this field will be equal to the tip the operator will receive on top of the
      * base cost of the transaction.
      * @param [transaction.bridgeAddress] The address of the bridge contract to be used.
-     * Defaults to the default zkSync Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
+     * Defaults to the default ZKsync Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
      * @param [transaction.l2GasLimit] Maximum amount of L2 gas that the transaction can consume during execution on L2.
      * @param [transaction.gasPerPubdataByte] The L2 gas price for each published L1 calldata byte.
      * @param [transaction.customBridgeData] Additional data that can be sent to a bridge.
@@ -745,7 +745,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
      * @param [transaction.operatorTip] (currently not used) If the ETH value passed with the transaction is not
      * explicitly stated in the overrides, this field will be equal to the tip the operator will receive on top of the
      * base cost of the transaction.
-     * @param [transaction.bridgeAddress] The address of the bridge contract to be used. Defaults to the default zkSync
+     * @param [transaction.bridgeAddress] The address of the bridge contract to be used. Defaults to the default ZKsync
      * Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
      * @param [transaction.l2GasLimit] Maximum amount of L2 gas that the transaction can consume during execution on L2.
      * @param [transaction.gasPerPubdataByte] The L2 gas price for each published L1 calldata byte.
@@ -1216,7 +1216,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
      * @param transaction.token The address of the token to deposit. ETH by default.
      * @param [transaction.to] The address that will receive the deposited tokens on L2.
      * @param [transaction.bridgeAddress] The address of the bridge contract to be used.
-     * Defaults to the default zkSync Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
+     * Defaults to the default ZKsync Era bridge (either `L1EthBridge` or `L1Erc20Bridge`).
      * @param [transaction.customBridgeData] Additional data that can be sent to a bridge.
      * @param [transaction.gasPerPubdataByte] The L2 gas price for each published L1 calldata byte.
      * @param [transaction.overrides] Transaction's overrides which may be used to pass L1 `gasLimit`, `gasPrice`, `value`, etc.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -42,7 +42,11 @@ import {
   RawBlockTransaction,
   PaymasterParams,
   StorageProof,
-  LogProof, Token, ProtocolVersion, FeeParams, TransactionWithDetailedOutput,
+  LogProof,
+  Token,
+  ProtocolVersion,
+  FeeParams,
+  TransactionWithDetailedOutput,
 } from './types';
 import {
   getL2HashFromPriorityOp,
@@ -489,9 +493,12 @@ export function JsonRpcApiProvider<
      * @param start The token id from which to start.
      * @param limit The maximum number of tokens to list.
      */
-    async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[]> {
-      const tokens: Token[] = await this.send("zks_getConfirmedTokens", [start, limit]);
-      return tokens.map((token) => ({ address: token.l2Address, ...token }));
+    async getConfirmedTokens(start = 0, limit = 255): Promise<Token[]> {
+      const tokens: Token[] = await this.send('zks_getConfirmedTokens', [
+        start,
+        limit,
+      ]);
+      return tokens.map(token => ({address: token.l2Address, ...token}));
     }
 
     /**
@@ -606,8 +613,12 @@ export function JsonRpcApiProvider<
      *
      * @param signedTx The signed transaction that needs to be broadcasted.
      */
-    async sendRawTransactionWithDetailedOutput(signedTx: string): Promise<TransactionWithDetailedOutput> {
-      return await this.send('zks_sendRawTransactionWithDetailedOutput', [signedTx]);
+    async sendRawTransactionWithDetailedOutput(
+      signedTx: string
+    ): Promise<TransactionWithDetailedOutput> {
+      return await this.send('zks_sendRawTransactionWithDetailedOutput', [
+        signedTx,
+      ]);
     }
 
     /**
@@ -1531,7 +1542,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    * const tokens = await provider.getConfirmedTokens();
    * console.log(`Confirmed tokens: ${utils.toJSON(tokens)}`);
    */
-  override async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[]> {
+  override async getConfirmedTokens(start = 0, limit = 255): Promise<Token[]> {
     return super.getConfirmedTokens(start, limit);
   }
 
@@ -1708,7 +1719,9 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    *
    * console.log(`Transaction with detailed output: ${utils.toJSON(txWithOutputs)}`);
    */
-  override async sendRawTransactionWithDetailedOutput(signedTx: string): Promise<TransactionWithDetailedOutput> {
+  override async sendRawTransactionWithDetailedOutput(
+    signedTx: string
+  ): Promise<TransactionWithDetailedOutput> {
     return super.sendRawTransactionWithDetailedOutput(signedTx);
   }
 
@@ -2556,7 +2569,7 @@ export class BrowserProvider extends JsonRpcApiProvider(
    * const tokens = await provider.getConfirmedTokens();
    * console.log(`Confirmed tokens: ${utils.toJSON(tokens)}`);
    */
-  override async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[]> {
+  override async getConfirmedTokens(start = 0, limit = 255): Promise<Token[]> {
     return super.getConfirmedTokens(start, limit);
   }
 
@@ -2734,7 +2747,9 @@ export class BrowserProvider extends JsonRpcApiProvider(
    * );
    * console.log(`Transaction with detailed output: ${utils.toJSON(txWithOutputs)}`);
    */
-  override async sendRawTransactionWithDetailedOutput(signedTx: string): Promise<TransactionWithDetailedOutput> {
+  override async sendRawTransactionWithDetailedOutput(
+    signedTx: string
+  ): Promise<TransactionWithDetailedOutput> {
     return super.sendRawTransactionWithDetailedOutput(signedTx);
   }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -42,6 +42,7 @@ import {
   RawBlockTransaction,
   PaymasterParams,
   StorageProof,
+  LogProof,
 } from './types';
 import {
   getL2HashFromPriorityOp,
@@ -85,7 +86,7 @@ export function JsonRpcApiProvider<
     }
 
     /**
-     * Returns the addresses of the main contract and default zkSync Era bridge contracts on both L1 and L2.
+     * Returns the addresses of the main contract and default ZKsync Era bridge contracts on both L1 and L2.
      */
     contractAddresses(): {
       bridgehubContract?: Address;
@@ -217,7 +218,7 @@ export function JsonRpcApiProvider<
      * Returns the L2 token address equivalent for a L1 token address as they are not equal.
      * ETH address is set to zero address.
      *
-     * @remarks Only works for tokens bridged on default zkSync Era bridges.
+     * @remarks Only works for tokens bridged on default ZKsync Era bridges.
      *
      * @param token The address of the token on L1.
      */
@@ -243,7 +244,7 @@ export function JsonRpcApiProvider<
      * Returns the L1 token address equivalent for a L2 token address as they are not equal.
      * ETH address is set to zero address.
      *
-     * @remarks Only works for tokens bridged on default zkSync Era bridges.
+     * @remarks Only works for tokens bridged on default ZKsync Era bridges.
      *
      * @param token The address of the token on L2.
      */
@@ -302,7 +303,7 @@ export function JsonRpcApiProvider<
     async getLogProof(
       txHash: BytesLike,
       index?: number
-    ): Promise<MessageProof | null> {
+    ): Promise<LogProof | null> {
       return await this.send('zks_getL2ToL1LogProof', [
         ethers.hexlify(txHash),
         index,
@@ -344,7 +345,7 @@ export function JsonRpcApiProvider<
     }
 
     /**
-     * Returns the main zkSync Era smart contract address.
+     * Returns the main ZKsync Era smart contract address.
      *
      * Calls the {@link https://docs.zksync.io/build/api.html#zks-getmaincontract zks_getMainContract} JSON-RPC method.
      */
@@ -404,7 +405,7 @@ export function JsonRpcApiProvider<
     }
 
     /**
-     * Returns the addresses of the default zkSync Era bridge contracts on both L1 and L2.
+     * Returns the addresses of the default ZKsync Era bridge contracts on both L1 and L2.
      *
      * Calls the {@link https://docs.zksync.io/build/api.html#zks-getbridgecontracts zks_getBridgeContracts} JSON-RPC method.
      */
@@ -980,7 +981,6 @@ export function JsonRpcApiProvider<
      * @param [transaction.gasPerPubdataByte] The current gas per byte value.
      * @param [transaction.overrides] Transaction overrides including `gasLimit`, `gasPrice`, and `value`.
      */
-    // TODO (EVM-3): support refundRecipient for fee estimation
     async estimateL1ToL2Execute(transaction: {
       contractAddress: Address;
       calldata: string;
@@ -1840,6 +1840,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    * @example
    *
    * import { Provider, types, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const ethProvider = ethers.getDefaultProvider("sepolia");
@@ -1861,6 +1862,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    * @example
    *
    * import { Provider, types, utils } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const ethProvider = ethers.getDefaultProvider("sepolia");
@@ -1967,7 +1969,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
   /**
    * Creates a new `Provider` from provided URL or network name.
    *
-   * @param zksyncNetwork The type of zkSync network.
+   * @param zksyncNetwork The type of ZKsync network.
    *
    * @example
    *
@@ -1995,7 +1997,7 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
 
 /* c8 ignore start */
 /**
- * A `BrowserProvider` extends {@link ethers.BrowserProvider} and includes additional features for interacting with zkSync Era.
+ * A `BrowserProvider` extends {@link ethers.BrowserProvider} and includes additional features for interacting with ZKsync Era.
  * It supports RPC endpoints within the `zks` namespace.
  * This provider is designed for frontend use in a browser environment and integration for browser wallets
  * (e.g., MetaMask, WalletConnect).
@@ -2949,6 +2951,13 @@ export class BrowserProvider extends JsonRpcApiProvider(
    * Resolves whether the provider manages the `address`.
    *
    * @param address The address to check.
+   *
+   * @example
+   *
+   * import { BrowserProvider, utils } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * const hasSigner = await provider.hasSigner(0);
    */
   override async hasSigner(address: number | string): Promise<boolean> {
     if (!address) {
@@ -2974,6 +2983,13 @@ export class BrowserProvider extends JsonRpcApiProvider(
    * @param address The address or index of the account to retrieve the signer for.
    *
    * @throws {Error} If the account doesn't exist.
+   *
+   * @example
+   *
+   * import { BrowserProvider, utils } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * const signer = await provider.getSigner();
    */
   override async getSigner(address?: number | string): Promise<Signer> {
     if (!address) {
@@ -2995,6 +3011,21 @@ export class BrowserProvider extends JsonRpcApiProvider(
     );
   }
 
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
+   * import { BrowserProvider, utils } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * const gas = await provider.estimate({
+   *   value: 7_000_000_000,
+   *   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+   *   from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+   * });
+   * console.log(`Gas: ${gas}`);
+   */
   override async estimateGas(transaction: TransactionRequest): Promise<bigint> {
     const gas = await super.estimateGas(transaction);
     const metamaskMinimum = 21_000n;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -42,7 +42,7 @@ import {
   RawBlockTransaction,
   PaymasterParams,
   StorageProof,
-  LogProof, Token, ProtocolVersion,
+  LogProof, Token, ProtocolVersion, FeeParams,
 } from './types';
 import {
   getL2HashFromPriorityOp,
@@ -293,6 +293,15 @@ export function JsonRpcApiProvider<
      */
     async estimateFee(transaction: TransactionRequest): Promise<Fee> {
       return await this.send('zks_estimateFee', [transaction]);
+    }
+
+    /**
+     * Returns the current fee parameters.
+     *
+     * Calls the {@link https://docs.zksync.io/build/api.html#zks_getFeeParams zks_getFeeParams} JSON-RPC method.
+     */
+    async getFeeParams(): Promise<FeeParams> {
+      return await this.send('zks_getFeeParams', []);
     }
 
     /**
@@ -1311,6 +1320,21 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    *
    * @example
    *
+   * import { Provider, types, utils } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const feeParams = await provider.getFeeParams();
+   * console.log(`Fee: ${utils.toJSON(feeParams)}`);
+   */
+  override async getFeeParams(): Promise<FeeParams> {
+    return super.getFeeParams();
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
    * import { Provider, types } from "zksync-ethers";
    *
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
@@ -2291,6 +2315,21 @@ export class BrowserProvider extends JsonRpcApiProvider(
    */
   override async estimateFee(transaction: TransactionRequest): Promise<Fee> {
     return super.estimateFee(transaction);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
+   * import { BrowserProvider, utils } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * const feeParams = await provider.getFeeParams();
+   * console.log(`Fee: ${utils.toJSON(feeParams)}`);
+   */
+  override async getFeeParams(): Promise<FeeParams> {
+    return super.getFeeParams();
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -42,7 +42,7 @@ import {
   RawBlockTransaction,
   PaymasterParams,
   StorageProof,
-  LogProof,
+  LogProof, Token,
 } from './types';
 import {
   getL2HashFromPriorityOp,
@@ -459,6 +459,19 @@ export function JsonRpcApiProvider<
         balances[token] = BigInt(balances[token]);
       }
       return balances;
+    }
+
+    /**
+     * Returns confirmed tokens. Confirmed token is any token bridged to ZKsync Era via the official bridge.
+     *
+     * Calls the {@link https://docs.zksync.io/build/api.html#zks_getconfirmedtokens zks_getConfirmedTokens} JSON-RPC method.
+     *
+     * @param start The token id from which to start.
+     * @param limit The maximum number of tokens to list.
+     */
+    async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[]> {
+      const tokens: Token[] = await this.send("zks_getConfirmedTokens", [start, limit]);
+      return tokens.map((token) => ({ address: token.l2Address, ...token }));
     }
 
     /**
@@ -1444,6 +1457,21 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    *
    * @example
    *
+   * import { Provider, types, utils } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const tokens = await provider.getConfirmedTokens();
+   * console.log(`Confirmed tokens: ${utils.toJSON(tokens)}`);
+   */
+  override async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[]> {
+    return super.getConfirmedTokens(start, limit);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
    * import { Provider, types} from "zksync-ethers";
    *
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
@@ -2393,6 +2421,21 @@ export class BrowserProvider extends JsonRpcApiProvider(
    */
   override async getAllAccountBalances(address: Address): Promise<BalancesMap> {
     return super.getAllAccountBalances(address);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
+   * import { BrowserProvider, utils } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * const tokens = await provider.getConfirmedTokens();
+   * console.log(`Confirmed tokens: ${utils.toJSON(tokens)}`);
+   */
+  override async getConfirmedTokens(start: number = 0, limit: number = 255): Promise<Token[]> {
+    return super.getConfirmedTokens(start, limit);
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -42,7 +42,7 @@ import {
   RawBlockTransaction,
   PaymasterParams,
   StorageProof,
-  LogProof, Token,
+  LogProof, Token, ProtocolVersion,
 } from './types';
 import {
   getL2HashFromPriorityOp,
@@ -260,6 +260,17 @@ export function JsonRpcApiProvider<
         this
       );
       return await sharedBridge.l1TokenAddress(token);
+    }
+
+    /**
+     * Return the protocol version
+     *
+     * Calls the {@link https://docs.zksync.io/build/api.html#zks_getprotocolversion zks_getProtocolVersion} JSON-RPC method.
+     *
+     * @param [id] Specific version ID.
+     */
+    async getProtocolVersion(id?: number): Promise<ProtocolVersion> {
+      return await this.send('zks_getProtocolVersion', [id]);
     }
 
     /**
@@ -1246,6 +1257,20 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    * import { Provider, types } from "zksync-ethers";
    *
    * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * console.log(`Protocol version: ${await provider.getProtocolVersion()}`);
+   */
+  override async getProtocolVersion(id?: number): Promise<ProtocolVersion> {
+    return super.getProtocolVersion(id);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
+   * import { Provider, types } from "zksync-ethers";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
    * const gasL1 = await provider.estimateGasL1({
    *   from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
    *   to: await provider.getMainContractAddress(),
@@ -2209,6 +2234,20 @@ export class BrowserProvider extends JsonRpcApiProvider(
    */
   override async l1TokenAddress(token: Address): Promise<string> {
     return super.l1TokenAddress(token);
+  }
+
+  /**
+   * @inheritDoc
+   *
+   * @example
+   *
+   * import { BrowserProvider } from "zksync-ethers";
+   *
+   * const provider = new BrowserProvider(window.ethereum);
+   * console.log(`Protocol version: ${await provider.getProtocolVersion()}`);
+   */
+  override async getProtocolVersion(id?: number): Promise<ProtocolVersion> {
+    return super.getProtocolVersion(id);
   }
 
   /**

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -37,7 +37,7 @@ import {
 } from './typechain';
 
 /**
- * All typed data conforming to the EIP712 standard within zkSync Era.
+ * All typed data conforming to the EIP712 standard within ZKsync Era.
  */
 export const EIP712_TYPES = {
   Transaction: [
@@ -58,11 +58,22 @@ export const EIP712_TYPES = {
 };
 
 /**
- * A `EIP712Signer` provides support for signing EIP712-typed zkSync Era transactions.
+ * A `EIP712Signer` provides support for signing EIP712-typed ZKsync Era transactions.
  */
 export class EIP712Signer {
   private eip712Domain: Promise<ethers.TypedDataDomain>;
 
+  /**
+   * @example
+   *
+   * import { Provider, types, EIP712Signer } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const signer = new EIP712Signer(new ethers.Wallet(PRIVATE_KEY, Number(await provider.getNetwork()));
+   */
   constructor(
     private ethSigner: ethers.Signer,
     chainId: number | Promise<number>
@@ -81,15 +92,17 @@ export class EIP712Signer {
    *
    * @example
    *
+   * import { EIP712Signer } from "zksync-ethers";
+   *
    * const tx = EIP712Signer.getSignInput({
    *   type: utils.EIP712_TX_TYPE,
    *   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
-   *   value: BigInt(7_000_000),
+   *   value: 7_000_000n,
    *   from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
-   *   nonce: 0,
-   *   chainId: BigInt(270),
-   *   gasPrice: BigInt(250_000_000),
-   *   gasLimit: BigInt(21_000),
+   *   nonce: 0n,
+   *   chainId: 270n,
+   *   gasPrice: 250_000_000n,
+   *   gasLimit: 21_000n,
    *   customData: {},
    * });
    */
@@ -127,6 +140,25 @@ export class EIP712Signer {
    *
    * @param transaction The transaction request that needs to be signed.
    * @returns A promise that resolves to the signature of the transaction.
+   *
+   * @example
+   *
+   * import { Provider, types, EIP712Signer } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const signer = new EIP712Signer(new ethers.Wallet(PRIVATE_KEY, Number(await provider.getNetwork()));
+   * const signature = signer.sign({
+   *   type: utils.EIP712_TX_TYPE,
+   *   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+   *   value: 7_000_000n,
+   *   nonce: 0n,
+   *   chainId: 270n,
+   *   gasPrice: 250_000_000n,
+   *   gasLimit: 21_000n,
+   * })
    */
   async sign(transaction: TransactionRequest): Promise<Signature> {
     return await this.ethSigner.signTypedData(
@@ -143,6 +175,22 @@ export class EIP712Signer {
    * @returns A hash (digest) of the transaction request.
    *
    * @throws {Error} If `transaction.chainId` is not set.
+   *
+   * @example
+   *
+   * import { EIP712Signer } from "zksync-ethers";
+   *
+   * const hash = EIP712Signer.getSignedDigest({
+   *   type: utils.EIP712_TX_TYPE,
+   *   to: "0xa61464658AfeAf65CccaaFD3a512b69A83B77618",
+   *   value: 7_000_000n,
+   *   from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+   *   nonce: 0n,
+   *   chainId: 270n,
+   *   gasPrice: 250_000_000n,
+   *   gasLimit: 21_000n,
+   *   customData: {},
+   * });
    */
   static getSignedDigest(transaction: TransactionRequest): ethers.BytesLike {
     if (!transaction.chainId) {
@@ -161,7 +209,18 @@ export class EIP712Signer {
   }
 
   /**
-   * Returns zkSync Era EIP712 domain.
+   * Returns ZKsync Era EIP712 domain.
+   *
+   * @example
+   *
+   * import { Provider, types, EIP712Signer } from "zksync-ethers";
+   * import { ethers } from "ethers";
+   *
+   * const PRIVATE_KEY = "<PRIVATE_KEY>";
+   *
+   * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+   * const signer = new EIP712Signer(new ethers.Wallet(PRIVATE_KEY, Number(await provider.getNetwork()));
+   * const domain = await signer.getDomain();
    */
   async getDomain(): Promise<ethers.TypedDataDomain> {
     return await this.eip712Domain;

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,31 @@ export interface Fee {
   maxFeePerGas: bigint;
 }
 
-
+/** Represents the fee parameters configuration. */
+export interface FeeParams {
+  /** Fee parameter configuration for the current version of the ZKsync protocol. */
+  V2: {
+    /** Settings related to transaction fee computation. */
+    config: {
+      /** Minimal gas price on L2. */
+      minimal_l2_gas_price: bigint,
+      /** Compute overhead part in fee calculation. */
+      compute_overhead_part: bigint,
+      /** Public data overhead part in fee calculation. */
+      pubdata_overhead_part: bigint,
+      /** Overhead in L1 gas for a batch of transactions. */
+      batch_overhead_l1_gas: bigint,
+      /** Maximum gas allowed per batch. */
+      max_gas_per_batch: bigint;
+      /** Maximum amount of public data allowed per batch. */
+      max_pubdata_per_batch: bigint;
+    },
+    /** Current L1 gas price. */
+    l1_gas_price: bigint;
+    /** Price of storing public data on L1. */
+    l1_pubdata_price: bigint;
+  }
+}
 
 /** Represents a message proof.
  *  @deprecated In favor of {@link LogProof}.

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,23 +137,23 @@ export interface FeeParams {
     /** Settings related to transaction fee computation. */
     config: {
       /** Minimal gas price on L2. */
-      minimal_l2_gas_price: bigint,
+      minimal_l2_gas_price: bigint;
       /** Compute overhead part in fee calculation. */
-      compute_overhead_part: bigint,
+      compute_overhead_part: bigint;
       /** Public data overhead part in fee calculation. */
-      pubdata_overhead_part: bigint,
+      pubdata_overhead_part: bigint;
       /** Overhead in L1 gas for a batch of transactions. */
-      batch_overhead_l1_gas: bigint,
+      batch_overhead_l1_gas: bigint;
       /** Maximum gas allowed per batch. */
       max_gas_per_batch: bigint;
       /** Maximum amount of public data allowed per batch. */
       max_pubdata_per_batch: bigint;
-    },
+    };
     /** Current L1 gas price. */
     l1_gas_price: bigint;
     /** Price of storing public data on L1. */
     l1_pubdata_price: bigint;
-  }
+  };
 }
 
 /** Represents a message proof.
@@ -935,23 +935,23 @@ export interface StorageProof {
 /** Represents the protocol version. */
 export interface ProtocolVersion {
   /** Protocol version ID. */
-  version_id: number,
+  version_id: number;
   /** Unix timestamp of the version's activation. */
-  timestamp: number,
+  timestamp: number;
   /** Contains the hashes of various verification keys used in the protocol. */
-   verification_keys_hashes: {
+  verification_keys_hashes: {
     params: {
       recursion_node_level_vk_hash: string;
       recursion_leaf_level_vk_hash: string;
       recursion_circuits_set_vks_hash: string;
-    },
+    };
     recursion_scheduler_level_vk_hash: string;
-  },
+  };
   /** Addresses of the base system contracts. */
   base_system_contracts: {
     bootloader: string;
     default_aa: string;
-  },
+  };
   /** Hash of the transaction used for the system upgrade, if any. */
   l2_system_upgrade_tx_hash: string | null;
 }
@@ -959,27 +959,27 @@ export interface ProtocolVersion {
 /** Represents the transaction with detailed output. */
 export interface TransactionWithDetailedOutput {
   /** Transaction hash. */
-  transactionHash: string,
+  transactionHash: string;
   /** Storage slots. */
   storageLogs: Array<{
-    address: string,
-    key: string,
-    writtenValue: string
+    address: string;
+    key: string;
+    writtenValue: string;
   }>;
   /** Generated events. */
   events: Array<{
     address: string;
     topics: string[];
     data: string;
-    blockHash: string | null,
-    blockNumber: bigint | null,
-    l1BatchNumber: bigint | null,
+    blockHash: string | null;
+    blockNumber: bigint | null;
+    l1BatchNumber: bigint | null;
     transactionHash: string;
     transactionIndex: bigint;
-    logIndex: bigint | null,
-    transactionLogIndex: bigint | null,
-    logType: string | null,
-    removed: boolean
+    logIndex: bigint | null;
+    transactionLogIndex: bigint | null;
+    logType: string | null;
+    removed: boolean;
   }>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -956,6 +956,33 @@ export interface ProtocolVersion {
   l2_system_upgrade_tx_hash: string | null;
 }
 
+/** Represents the transaction with detailed output. */
+export interface TransactionWithDetailedOutput {
+  /** Transaction hash. */
+  transactionHash: string,
+  /** Storage slots. */
+  storageLogs: Array<{
+    address: string,
+    key: string,
+    writtenValue: string
+  }>;
+  /** Generated events. */
+  events: Array<{
+    address: string;
+    topics: string[];
+    data: string;
+    blockHash: string | null,
+    blockNumber: bigint | null,
+    l1BatchNumber: bigint | null,
+    transactionHash: string;
+    transactionIndex: bigint;
+    logIndex: bigint | null,
+    transactionLogIndex: bigint | null,
+    logType: string | null,
+    removed: boolean
+  }>;
+}
+
 /**
  *  Signs various types of payloads, optionally using a some kind of secret.
  *

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,35 +106,55 @@ export type DeploymentType =
 
 /** Bridged token. */
 export interface Token {
+  /** Token address on L1. */
   l1Address: Address;
+  /** Token address on L2. */
   l2Address: Address;
+  /** Token name. */
   name: string;
+  /** Token symbol. */
   symbol: string;
+  /** Token decimals. */
   decimals: number;
 }
 
 /** Represents the transaction fee parameters. */
 export interface Fee {
-  /** The maximum amount of gas allowed for the transaction. */
+  /** The maximum amount of gas that can be used. */
   gasLimit: bigint;
-  /** The maximum amount of gas the user is willing to pay for a single byte of pubdata. */
+  /** The gas limit per unit of public data. */
   gasPerPubdataLimit: bigint;
-  /** The EIP1559 tip per gas. */
+  /** The maximum priority fee per unit of gas to incentivize miners. */
   maxPriorityFeePerGas: bigint;
-  /** The EIP1559 fee cap per gas. */
+  /** The maximum fee per unit of gas that the sender is willing to pay. */
   maxFeePerGas: bigint;
 }
 
-/** Represents a message proof. */
+/** Represents a message proof.
+ *  @deprecated In favor of {@link LogProof}.
+ */
 export interface MessageProof {
+  /** Identifier of the log within the transaction. */
   id: number;
+  /** Each element represents a piece of the proof for the specified log. */
   proof: string[];
+  /** Root hash of the proof, anchoring it to a specific state in the blockchain. */
+  root: string;
+}
+
+/** Represents a log proof for an L2 to L1 transaction. */
+export interface LogProof {
+  /** Identifier of the log within the transaction. */
+  id: number;
+  /** Each element represents a piece of the proof for the specified log. */
+  proof: string[];
+  /** Root hash of the proof, anchoring it to a specific state in the blockchain. */
   root: string;
 }
 
 /**
  * A `TransactionResponse` is an extension of {@link ethers.TransactionResponse} with additional features for
- * interacting with zkSync Era.
+ * interacting with ZKsync Era.
  */
 export class TransactionResponse extends ethers.TransactionResponse {
   /** The batch number on the L1 network. */
@@ -216,7 +236,7 @@ export class TransactionResponse extends ethers.TransactionResponse {
 
 /**
  * A `TransactionReceipt` is an extension of {@link ethers.TransactionReceipt} with additional features for
- * interacting with zkSync Era.
+ * interacting with ZKsync Era.
  */
 export class TransactionReceipt extends ethers.TransactionReceipt {
   /** The batch number on the L1 network. */
@@ -266,7 +286,7 @@ export class TransactionReceipt extends ethers.TransactionReceipt {
   }
 }
 
-/** A `Block` is an extension of {@link ethers.Block} with additional features for interacting with zkSync Era. */
+/** A `Block` is an extension of {@link ethers.Block} with additional features for interacting with ZKsync Era. */
 export class Block extends ethers.Block {
   /** The batch number on L1. */
   readonly l1BatchNumber!: null | number;
@@ -358,13 +378,13 @@ export class Block extends ethers.Block {
   }
 }
 
-/** A `LogParams` is an extension of {@link ethers.LogParams} with additional features for interacting with zkSync Era. */
+/** A `LogParams` is an extension of {@link ethers.LogParams} with additional features for interacting with ZKsync Era. */
 export interface LogParams extends ethers.LogParams {
   /** The batch number on L1. */
   readonly l1BatchNumber: null | number;
 }
 
-/** A `Log` is an extension of {@link ethers.Log} with additional features for interacting with zkSync Era. */
+/** A `Log` is an extension of {@link ethers.Log} with additional features for interacting with ZKsync Era. */
 export class Log extends ethers.Log {
   /** The batch number on L1. */
   readonly l1BatchNumber: null | number;
@@ -397,7 +417,7 @@ export class Log extends ethers.Log {
 
 /**
  * A `TransactionLike` is an extension of {@link ethers.TransactionLike} with additional features for interacting
- * with zkSync Era.
+ * with ZKsync Era.
  */
 export interface TransactionLike extends ethers.TransactionLike {
   /** The custom data for EIP712 transaction metadata. */
@@ -406,7 +426,7 @@ export interface TransactionLike extends ethers.TransactionLike {
 
 /**
  * A `Transaction` is an extension of {@link ethers.Transaction} with additional features for interacting
- * with zkSync Era.
+ * with ZKsync Era.
  */
 export class Transaction extends ethers.Transaction {
   /** The custom data for EIP712 transaction metadata. */
@@ -549,22 +569,36 @@ export class Transaction extends ethers.Transaction {
  * Represents a L2 to L1 transaction log.
  */
 export interface L2ToL1Log {
+  /** The block number. */
   blockNumber: number;
+  /** The block hash. */
   blockHash: string;
+  /** The batch number on L1. */
   l1BatchNumber: number;
+  /** The L2 transaction number in a block, in which the log was sent. */
   transactionIndex: number;
+  /** The shard identifier, 0 - rollup, 1 - porter. */
   shardId: number;
+  /**
+   *  A boolean flag that is part of the log along with `key`, `value`, and `sender` address.
+   *  This field is required formally but does not have any special meaning.
+   */
   isService: boolean;
+  /** The L2 address which sent the log. */
   sender: string;
+  /** The 32 bytes of information that was sent in the log. */
   key: string;
+  /** The 32 bytes of information that was sent in the log. */
   value: string;
+  /** The transaction hash. */
   transactionHash: string;
+  /** The log index. */
   logIndex: number;
 }
 
 /**
  * A `TransactionRequest` is an extension of {@link ethers.TransactionRequest} with additional features for interacting
- * with zkSync Era.
+ * with ZKsync Era.
  */
 export interface TransactionRequest extends EthersTransactionRequest {
   /** The custom data for EIP712 transaction metadata. */
@@ -584,7 +618,10 @@ export interface PriorityOpResponse extends TransactionResponse {
   waitL1Commit(confirmation?: number): Promise<ethers.TransactionReceipt>;
 }
 
-/** A map containing accounts and their balances. */
+/**
+ * A map  with token addresses as keys and their corresponding balances as values.
+ * Each key-value pair represents the balance of a specific token held by the account.
+ */
 export type BalancesMap = {[key: string]: bigint};
 
 /** Represents deployment information. */
@@ -643,9 +680,9 @@ export type PaymasterInput =
 
 /** Enumerated list of account abstraction versions. */
 export enum AccountAbstractionVersion {
-  /** Used for contracts that are not accounts */
+  /** Used for contracts that are not accounts. */
   None = 0,
-  /** Used for contracts that are accounts */
+  /** Used for contracts that are accounts. */
   Version1 = 1,
 }
 
@@ -674,50 +711,105 @@ export interface ContractAccountInfo {
   nonceOrdering: AccountNonceOrdering;
 }
 
-/** Contains batch information. */
+/** Contains L1 batch details. */
 export interface BatchDetails {
+  /** L1 batch number. */
   number: number;
+  /** Unix timestamp when the batch was processed. */
   timestamp: number;
+  /** Number of L1 transactions included in the batch. */
   l1TxCount: number;
+  /** Number of L2 transactions associated with this batch. */
   l2TxCount: number;
+  /** Root hash of the state after processing the batch. */
   rootHash?: string;
+  /** Current status of the batch (e.g., verified). */
   status: string;
+  /** Transaction hash of the commit operation on L1. */
   commitTxHash?: string;
+  /** Timestamp when the block was committed on L1. */
   committedAt?: Date;
+  /** Transaction hash of the proof submission on L1. */
   proveTxHash?: string;
+  /** Timestamp when the proof was submitted on L1. */
   provenAt?: Date;
+  /** Transaction hash of the execution on L1. */
   executeTxHash?: string;
+  /** Timestamp when the block execution was completed on L1. */
   executedAt?: Date;
+  /** L1 gas price at the time of the block's execution. */
   l1GasPrice: number;
+  /** Fair gas price on L2 at the time of the block's execution. */
   l2FairGasPrice: number;
+  /** Hashes of the base system contracts involved in the batch. */
+  baseSystemContractsHashes: {
+    bootloader: string;
+    default_aa: string;
+  };
 }
 
 /** Contains block information. */
 export interface BlockDetails {
+  /** Number of the block. */
   number: number;
+  /** Unix timestamp when the block was committed. */
   timestamp: number;
+  /** Corresponding L1 batch number. */
   l1BatchNumber: number;
+  /** Number of L1 transactions included in the block. */
   l1TxCount: number;
+  /** Number of L2 transactions included in the block. */
   l2TxCount: number;
+  /** Root hash of the block's state after execution. */
   rootHash?: string;
+  /** Current status of the block (e.g., verified, executed). */
   status: string;
+  /** Transaction hash of the commit operation on L1. */
   commitTxHash?: string;
+  /** Timestamp when the block was committed on L1. */
   committedAt?: Date;
+  /** Transaction hash of the proof submission on L1. */
   proveTxHash?: string;
+  /** Timestamp when the proof was submitted on L1. */
   provenAt?: Date;
+  /** Transaction hash of the execution on L1. */
   executeTxHash?: string;
+  /** Timestamp when the block execution was completed on L1. */
   executedAt?: Date;
+  /** L1 gas price at the time of the block's execution. */
+  l1GasPrice: number;
+  /** Fair gas price on L2 at the time of the block's execution. */
+  l2FairGasPrice: number;
+  /** A collection of hashes for the base system contracts involved in the block. */
+  baseSystemContractsHashes: {
+    bootloader: string;
+    default_aa: string;
+  };
+  /** Address of the operator who committed the block. */
+  operatorAddress: string;
+  /** version of the ZKsync protocol the block was committed under. */
+  protocolVersion: string;
 }
 
 /** Contains transaction details information. */
 export interface TransactionDetails {
+  /** Indicates whether the transaction originated on Layer 1. */
   isL1Originated: boolean;
+  /** Current status of the transaction (e.g., verified). */
   status: string;
+  /** Transaction fee. */
   fee: BigNumberish;
+  /** Gas amount per unit of public data for this transaction. */
+  gasPerPubdata: BigNumberish;
+  /** Address of the transaction initiator. */
   initiatorAddress: Address;
+  /** Timestamp when the transaction was received. */
   receivedAt: Date;
+  /** Transaction hash of the commit operation. */
   ethCommitTxHash?: string;
+  /** Transaction hash of the proof submission. */
   ethProveTxHash?: string;
+  /** Transaction hash of the execution. */
   ethExecuteTxHash?: string;
 }
 
@@ -739,52 +831,77 @@ export interface FullDepositFee {
 
 /** Represents a raw block transaction. */
 export interface RawBlockTransaction {
+  /** General information about the L2 transaction */
   common_data: {
-    L1: {
-      canonicalTxHash: string;
-      deadlineBlock: number;
-      ethBlock: number;
-      ethHash: string;
-      fullFee: bigint;
-      gasLimit: bigint;
-      gasPerPubdataLimit: bigint;
-      layer2TipFee: bigint;
-      maxFeePerGas: bigint;
-      opProcessingType: string;
-      priorityQueueType: string;
-      refundRecipient: Address;
-      sender: Address;
-      serialId: number;
-      toMint: string;
+    L2: {
+      nonce: number;
+      fee: {
+        gas_limit: bigint;
+        max_fee_per_gas: bigint;
+        max_priority_fee_per_gas: bigint;
+        gas_per_pubdata_limit: bigint;
+      };
+      initiatorAddress: Address;
+      signature: BytesLike[];
+      transactionType: string;
+      input: {
+        hash: string;
+        data: BytesLike[];
+      };
+      paymasterParams: {
+        paymaster: Address;
+        paymasterInput: BytesLike[];
+      };
     };
   };
+  /** Details regarding the execution of the transaction. */
   execute: {
     calldata: string;
     contractAddress: Address;
-    factoryDeps: BytesLike[];
+    factoryDeps: BytesLike[] | null;
     value: bigint;
   };
+  /** Timestamp when the transaction was received, in milliseconds. */
   received_timestamp_ms: number;
+  /** Raw bytes of the transaction as a hexadecimal string. */
   raw_bytes: string | null;
 }
 
 /** Contains parameters for finalizing the withdrawal transaction. */
 export interface FinalizeWithdrawalParams {
+  /** The L2 batch number where the withdrawal was processed. */
   l1BatchNumber: number | null;
+  /** The position in the L2 logs Merkle tree of the l2Log that was sent with the message. */
   l2MessageIndex: number;
+  /** The L2 transaction number in the batch, in which the log was sent. */
   l2TxNumberInBlock: number | null;
+  /** The L2 withdraw data, stored in an L2 -> L1 message. */
   message: any;
+  /** The L2 address which sent the log. */
   sender: string;
+  /** The Merkle proof of the inclusion L2 -> L1 message about withdrawal initialization. */
   proof: string[];
 }
 
-/** Represents storage proof */
+/** Represents storage proof. */
 export interface StorageProof {
+  /** Account address associated with the storage proofs. */
   address: string;
+  /** Array of objects, each representing a storage proof for the requested keys. */
   storageProof: {
+    /** Storage key for which the proof is provided. */
     key: string;
+    /** Value stored in the specified storage key at the time of the specified l1BatchNumber. */
     value: string;
+    /**
+     * A 1-based index representing the position of the tree entry within the Merkle tree.
+     * This index is used to help reconstruct the Merkle path during verification.
+     */
     index: number;
+    /**
+     * An array of 32-byte hashes that constitute the Merkle path from the leaf node
+     * (representing the storage key-value pair) to the root of the Merkle tree.
+     */
     proof: string[];
   }[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,8 @@ export interface Fee {
   maxFeePerGas: bigint;
 }
 
+
+
 /** Represents a message proof.
  *  @deprecated In favor of {@link LogProof}.
  */
@@ -904,6 +906,30 @@ export interface StorageProof {
      */
     proof: string[];
   }[];
+}
+
+/** Represents the protocol version. */
+export interface ProtocolVersion {
+  /** Protocol version ID. */
+  version_id: number,
+  /** Unix timestamp of the version's activation. */
+  timestamp: number,
+  /** Contains the hashes of various verification keys used in the protocol. */
+   verification_keys_hashes: {
+    params: {
+      recursion_node_level_vk_hash: string;
+      recursion_leaf_level_vk_hash: string;
+      recursion_circuits_set_vks_hash: string;
+    },
+    recursion_scheduler_level_vk_hash: string;
+  },
+  /** Addresses of the base system contracts. */
+  base_system_contracts: {
+    bootloader: string;
+    default_aa: string;
+  },
+  /** Hash of the transaction used for the system upgrade, if any. */
+  l2_system_upgrade_tx_hash: string | null;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ export * from './smart-account-utils';
 export {EIP712_TYPES} from './signer';
 
 /**
- * The ABI for the `ZkSync` interface.
+ * The ABI for the `ZKsync` interface.
  * @constant
  */
 export const ZKSYNC_MAIN_ABI = new ethers.Interface(IZkSyncABI);
@@ -243,6 +243,8 @@ export const REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT = 800;
  *
  * @example
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const isL1ETH = utils.isETH(utils.ETH_ADDRESS); // true
  * const isL2ETH = utils.isETH(utils.ETH_ADDRESS_IN_CONTRACTS); // true
  */
@@ -261,7 +263,9 @@ export function isETH(token: Address) {
  *
  * @example
  *
- * await sleep(1_000);
+ * import { utils } from "zksync-ethers";
+ *
+ * await utils.sleep(1_000);
  */
 export function sleep(millis: number): Promise<unknown> {
   return new Promise(resolve => setTimeout(resolve, millis));
@@ -289,6 +293,8 @@ export function layer1TxDefaults(): {
  * @returns The hashed `L2->L1` message.
  *
  * @example
+ *
+ * import { utils } from "zksync-ethers";
  *
  * const withdrawETHMessage = "0x6c0960f936615cf349d7f6344891b1e7ca7c72883f5dc04900000000000000000000000000000000000000000000000000000001a13b8600";
  * const withdrawETHMessageHash = utils.getHashedL2ToL1Msg("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049", withdrawETHMessage, 0);
@@ -318,7 +324,13 @@ export function getHashedL2ToL1Msg(
  *
  * @example
  *
+ * import { Provider, types, utils } from "zksync-ethers";
  *
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ *
+ * const deployTx = "<DEPLOY TRANSACTION>";
+ * const receipt = await provider.getTransactionReceipt(deployTx);
+ * const deploymentInfo = utils.getDeployedContracts(receipt as ethers.TransactionReceipt);
  */
 export function getDeployedContracts(
   receipt: ethers.TransactionReceipt
@@ -358,9 +370,11 @@ export function getDeployedContracts(
  * @param salt A randomization element used to create the contract address.
  * @param input The ABI-encoded constructor arguments, if any.
  *
- * @remarks The implementation of `create2Address` in zkSync Era may differ slightly from Ethereum.
+ * @remarks The implementation of `create2Address` in ZKsync Era may differ slightly from Ethereum.
  *
  * @example
+ *
+ * import { utils } from "zksync-ethers";
  *
  * const address = utils.create2Address("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049", "0x010001cb6a6e8d5f6829522f19fa9568660e0a9cd53b2e8be4deb0a679452e41", "0x01", "0x01");
  * // address = "0x29bac3E5E8FFE7415F97C956BFA106D70316ad50"
@@ -395,6 +409,8 @@ export function create2Address(
  *
  * @example
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const address = utils.createAddress("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049", 1);
  * // address = "0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021"
  */
@@ -425,6 +441,8 @@ export function createAddress(
  *
  * @example
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const baseCost = 100;
  * const value = 99;
  * try {
@@ -449,7 +467,7 @@ export async function checkBaseCost(
  * Serializes an EIP712 transaction and includes a signature if provided.
  *
  * @param transaction The transaction that needs to be serialized.
- * @param signature Ethers signature to be included in the transaction.
+ * @param [signature] Ethers signature to be included in the transaction.
  * @throws {Error} Throws an error if:
  * - `transaction.customData.customSignature` is an empty string. The transaction should be signed, and the `transaction.customData.customSignature` field should be populated with the signature. It should not be specified if the transaction is not signed.
  * - `transaction.chainId` is not provided.
@@ -457,11 +475,16 @@ export async function checkBaseCost(
  *
  * @example Serialize EIP712 transaction without signature.
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const serializedTx = utils.serializeEip712({ chainId: 270, from: "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049" }, null);
  *
  * // serializedTx = "0x71ea8080808080808082010e808082010e9436615cf349d7f6344891b1e7ca7c72883f5dc04982c350c080c0"
  *
  * @example Serialize EIP712 transaction with signature.
+ *
+ * import { utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
  *
  * const signature = ethers.Signature.from("0x73a20167b8d23b610b058c05368174495adf7da3a4ed4a57eb6dbdeb1fafc24aaf87530d663a0d061f69bb564d2c6fb46ae5ae776bbd4bd2a2a4478b9cd1b42a");
  *
@@ -553,6 +576,8 @@ export function serializeEip712(
  *
  * @example
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const bytecode =
  *   "0x000200000000000200010000000103550000006001100270000000130010019d0000008001000039000000400010043f0000000101200190000000290000c13d0000000001000031000000040110008c000000420000413d0000000101000367000000000101043b000000e001100270000000150210009c000000310000613d000000160110009c000000420000c13d0000000001000416000000000110004c000000420000c13d000000040100008a00000000011000310000001702000041000000200310008c000000000300001900000000030240190000001701100197000000000410004c000000000200a019000000170110009c00000000010300190000000001026019000000000110004c000000420000c13d00000004010000390000000101100367000000000101043b000000000010041b0000000001000019000000490001042e0000000001000416000000000110004c000000420000c13d0000002001000039000001000010044300000120000004430000001401000041000000490001042e0000000001000416000000000110004c000000420000c13d000000040100008a00000000011000310000001702000041000000000310004c000000000300001900000000030240190000001701100197000000000410004c000000000200a019000000170110009c00000000010300190000000001026019000000000110004c000000440000613d00000000010000190000004a00010430000000000100041a000000800010043f0000001801000041000000490001042e0000004800000432000000490001042e0000004a00010430000000000000000000000000000000000000000000000000000000000000000000000000ffffffff0000000200000000000000000000000000000040000001000000000000000000000000000000000000000000000000000000000000000000000000006d4ce63c0000000000000000000000000000000000000000000000000000000060fe47b18000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000080000000000000000000000000000000000000000000000000000000000000000000000000000000009c8c8fa789967eb514f3ec9def748480945cc9b10fcbd1a19597d924eb201083";
  * const hashedBytecode = utils.hashBytecode(bytecode);
@@ -610,7 +635,7 @@ export function hashBytecode(bytecode: ethers.BytesLike): Uint8Array {
  *
  * @example
  *
- * import { types } from "zksync-ethers";
+ * import { utils, types } from "zksync-ethers";
  *
  * const serializedTx =
  *   "0x71f87f8080808094a61464658afeaf65cccaafd3a512b69a83b77618830f42408001a073a20167b8d23b610b058c05368174495adf7da3a4ed4a57eb6dbdeb1fafc24aa02f87530d663a0d061f69bb564d2c6fb46ae5ae776bbd4bd2a2a4478b9cd1b42a82010e9436615cf349d7f6344891b1e7ca7c72883f5dc04982c350c080c0";
@@ -721,6 +746,59 @@ export function parseEip712(payload: ethers.BytesLike): TransactionLike {
   return transaction;
 }
 
+/**
+ * Returns the custom signature from EIP712 transaction if provided,
+ * otherwise returns the Ethereum signature in bytes representation.
+ *
+ * @param transaction The EIP712 transaction that may contain a custom signature.
+ * If a custom signature is not present in the transaction, the `ethSignature` parameter will be used.
+ * @param [ethSignature] The Ethereum transaction signature. This parameter is ignored if the transaction
+ * object contains a custom signature.
+ *
+ * @example Get custom signature from the EIP712 transaction.
+ *
+ * import { utils, types } from "zksync-ethers";
+ *
+ * const tx: types.TransactionLike = {
+ *   type: 113,
+ *   nonce: 0,
+ *   maxPriorityFeePerGas: 0n,
+ *   maxFeePerGas: 0n,
+ *   gasLimit: 0n,
+ *   to: '0xa61464658AfeAf65CccaaFD3a512b69A83B77618',
+ *   value: 1_000_000n,
+ *   data: '0x',
+ *   chainId: 270n,
+ *   from: '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049',
+ *   customData: {
+ *     gasPerPubdata: 50_000n,
+ *     factoryDeps: [],
+ *     customSignature:
+ *       '0x307837373262396162343735386435636630386637643732303161646332653534383933616532376263666562323162396337643666643430393766346464653063303166376630353332323866346636643838653662663334333436343931343135363761633930363632306661653832633239333339393062353563613336363162',
+ *     paymasterParams: {
+ *       paymaster: '0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174',
+ *       paymasterInput: ethers.getBytes(
+ *         '0x949431dc000000000000000000000000841c43fa5d8fffdb9efe3358906f7578d8700dd4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000'
+ *       ),
+ *     },
+ *   },
+ *   hash: '0xc0ba55587423e1ef281b06a9d684b481365897f37a6ad611d7619b1b7e0bc908',
+ * };
+ *
+ * const signature = utils.getSignature(tx);
+ * // signature = '0x307837373262396162343735386435636630386637643732303161646332653534383933616532376263666562323162396337643666643430393766346464653063303166376630353332323866346636643838653662663334333436343931343135363761633930363632306661653832633239333339393062353563613336363162'
+ *
+ * @example Get Ethereum transaction signature.
+ *
+ * import { utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
+ *
+ * const ethSignature = ethers.Signature.from(
+ *   '0x73a20167b8d23b610b058c05368174495adf7da3a4ed4a57eb6dbdeb1fafc24aaf87530d663a0d061f69bb564d2c6fb46ae5ae776bbd4bd2a2a4478b9cd1b42a'
+ * );
+ * const signature =  utils.getSignature(undefined, ethSignature);
+ * // signature = '0x73a20167b8d23b610b058c05368174495adf7da3a4ed4a57eb6dbdeb1fafc24aaf87530d663a0d061f69bb564d2c6fb46ae5ae776bbd4bd2a2a4478b9cd1b42a'
+ */
 function getSignature(
   transaction: any,
   ethSignature?: EthereumSignature
@@ -744,14 +822,63 @@ function getSignature(
 }
 
 /**
- * Returns the hash of an EIP712 transaction.
+ * Returns the hash of an EIP712 transaction. If a custom signature is provided in the transaction,
+ * it will be used to form the transaction hash. Otherwise, the Ethereum signature specified in the
+ * `ethSignature` parameter will be used.
  *
- * @param transaction The EIP-712 transaction.
- * @param ethSignature The ECDSA signature of the transaction.
+ * @param transaction The EIP712 transaction that may contain a custom signature.
+ * If a custom signature is not present in the transaction, the `ethSignature` parameter will be used.
+ * @param [ethSignature] The Ethereum transaction signature. This parameter is ignored if the transaction
+ * object contains a custom signature.
  *
- * @example
+ * @example Get transaction hash using custom signature from the transaction.
  *
+ * import { utils } from "zksync-ethers";
  *
+ * const tx: types.TransactionRequest = {
+ *   type: 113,
+ *   nonce: 0,
+ *   maxPriorityFeePerGas: 0n,
+ *   maxFeePerGas: 0n,
+ *   gasLimit: 0n,
+ *   to: '0xa61464658AfeAf65CccaaFD3a512b69A83B77618',
+ *   value: 1_000_000n,
+ *   data: '0x',
+ *   chainId: 270n,
+ *   from: '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049',
+ *   customData: {
+ *     gasPerPubdata: 50_000n,
+ *     factoryDeps: [],
+ *     customSignature:
+ *       '0x307837373262396162343735386435636630386637643732303161646332653534383933616532376263666562323162396337643666643430393766346464653063303166376630353332323866346636643838653662663334333436343931343135363761633930363632306661653832633239333339393062353563613336363162',
+ *     paymasterParams: {
+ *       paymaster: '0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174',
+ *       paymasterInput: ethers.getBytes(
+ *         '0x949431dc000000000000000000000000841c43fa5d8fffdb9efe3358906f7578d8700dd4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000'
+ *       ),
+ *     },
+ *   },
+ * };
+ *
+ * const hash = utils.eip712TxHash(tx);
+ * // hash = '0xc0ba55587423e1ef281b06a9d684b481365897f37a6ad611d7619b1b7e0bc908'
+ *
+ * @example Get transaction hash using Ethereum signature.
+ *
+ * import { utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
+ *
+ * const tx: types.TransactionRequest = {
+ *   chainId: 270n,
+ *   from: '0x36615Cf349d7F6344891B1e7CA7C72883F5dc049',
+ *   to: '0xa61464658AfeAf65CccaaFD3a512b69A83B77618',
+ *   value: 1_000_000n,
+ * };
+ * const signature = ethers.Signature.from(
+ *   '0x73a20167b8d23b610b058c05368174495adf7da3a4ed4a57eb6dbdeb1fafc24aaf87530d663a0d061f69bb564d2c6fb46ae5ae776bbd4bd2a2a4478b9cd1b42a'
+ * );
+ * const hash = utils.eip712TxHash(tx, signature);
+ * // hash = '0x8efdc7ce5f5a75ab945976c3e2b0c2a45e9f8e15ff940d05625ac5545cd9f870'
  */
 export function eip712TxHash(
   transaction: Transaction | TransactionRequest,
@@ -769,9 +896,23 @@ export function eip712TxHash(
  * Returns the hash of the L2 priority operation from a given transaction receipt and L2 address.
  *
  * @param txReceipt The receipt of the L1 transaction.
- * @param zkSyncAddress The address of the zkSync Era main contract.
+ * @param zkSyncAddress The address of the ZKsync Era main contract.
  *
  * @example
+ *
+ * import { Provider, types, utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
+ *
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ * const ethProvider = ethers.getDefaultProvider("sepolia");
+ * const l1Tx = "0xcca5411f3e514052f4a4ae1c2020badec6e0998adb52c09959c5f5ff15fba3a8";
+ * const l1TxReceipt = await ethProvider.getTransactionReceipt(l1Tx);
+ * if (l1TxReceipt) {
+ *   const l2Hash = getL2HashFromPriorityOp(
+ *     receipt as ethers.TransactionReceipt,
+ *     await provider.getMainContractAddress()
+ *   );
+ * }
  */
 export function getL2HashFromPriorityOp(
   txReceipt: ethers.TransactionReceipt,
@@ -821,10 +962,11 @@ const ADDRESS_MODULO = 2n ** 160n;
  *
  * @example
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const l1ContractAddress = "0x702942B8205E5dEdCD3374E5f4419843adA76Eeb";
  * const l2ContractAddress = utils.applyL1ToL2Alias(l1ContractAddress);
  * // l2ContractAddress = "0x813A42B8205E5DedCd3374e5f4419843ADa77FFC"
- *
  */
 export function applyL1ToL2Alias(address: string): string {
   return ethers.toBeHex(
@@ -842,6 +984,8 @@ export function applyL1ToL2Alias(address: string): string {
  * {@link applyL1ToL2Alias}.
  *
  * @example
+ *
+ * import { utils } from "zksync-ethers";
  *
  * const l2ContractAddress = "0x813A42B8205E5DedCd3374e5f4419843ADa77FFC";
  * const l1ContractAddress = utils.undoL1ToL2Alias(l2ContractAddress);
@@ -861,6 +1005,16 @@ export function undoL1ToL2Alias(address: string): string {
  * @param l1TokenAddress The token address on L1.
  * @param provider The client that is able to work with contracts on a read-write basis.
  * @returns The encoded bytes which contains token name, symbol and decimals.
+ *
+ * @example
+ *
+ * import { utils, types } from "zksync-ethers";
+ * import { ethers } from "ethers";
+ *
+ * const ethProvider = ethers.getDefaultProvider("sepolia");
+ * const tokenL1 = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
+ *
+ * const calldata = await utils.getERC20DefaultBridgeData(tokenL1, ethProvider);
  */
 export async function getERC20DefaultBridgeData(
   l1TokenAddress: string,
@@ -904,7 +1058,30 @@ export async function getERC20DefaultBridgeData(
  *
  * @example
  *
+ * import { Provider, utils, types } from "zksync-ethers";
  *
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ *
+ * const l1TokenAddress = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
+ * const l1Sender = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const l2Receiver = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const amount = 5;
+ * const bridgeData = "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000
+ * 0000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000016000000000000000000000
+ * 000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000
+ * 000000000000000000000000000000000000000000000000000000543726f776e0000000000000000000000000000000000000000000000000000
+ * 000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000
+ * 0000000000020000000000000000000000000000000000000000000000000000000000000000543726f776e000000000000000000000000000000
+ * 000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000
+ * 00000000000000000000000000000000012";
+ *
+ * const calldata = await utils.getERC20BridgeCalldata(
+ *   l1TokenAddress,
+ *   l1Sender,
+ *   l2Receiver,
+ *   amount,
+ *   bridgeData
+ * );
  */
 export async function getERC20BridgeCalldata(
   l1TokenAddress: string,
@@ -936,6 +1113,7 @@ export async function getERC20BridgeCalldata(
  * @example
  *
  * import { Wallet, utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
  *
  * const ADDRESS = "<WALLET_ADDRESS>";
  * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -977,6 +1155,24 @@ function isECDSASignatureCorrect(
  *
  * @example
  *
+ * import { MultisigECDSASmartAccount, Provider, utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
+ *
+ * const ADDRESS = "<MULTISIG ACCOUNT ADDRESS>";
+ * const PRIVATE_KEY1 = "<FIRST PRIVATE KEY>;
+ * const PRIVATE_KEY2 = "<SECOND PRIVATE KEY>;
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ *
+ * const account = MultisigECDSASmartAccount.create(
+ *   ADDRESS,
+ *   [PRIVATE_KEY1, PRIVATE_KEY2],
+ *   provider
+ * );
+ *
+ * const message = "Hello World";
+ * const signature = await account.signMessage(message);
+ * const magicValue = await utils.isEIP1271SignatureCorrect(provider, ADDRESS, msgHash, signature);
+ * // magicValue = "0x1626ba7e"
  */
 async function isEIP1271SignatureCorrect(
   provider: Provider,
@@ -1007,6 +1203,23 @@ async function isEIP1271SignatureCorrect(
  * @param address The sender address.
  * @param msgHash The hash of the message.
  * @param signature The Ethers signature.
+ *
+ * @example
+ *
+ * import { Provider, utils } from "zksync-ethers";
+ * import { ethers } from "ethers";
+ *
+ * const ADDRESS = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const MSG_HASH = "<WALLET_PRIVATE_KEY>";
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ *
+ * const isCorrect = await utils.isSignatureCorrect(
+ *   provider,
+ *   "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+ *   "0xb453bd4e271eed985cbab8231da609c4ce0a9cf1f763b6c1594e76315510e0f1",
+ *   "0xb04f825363596418c630425916f73447d636094a75e47b45e2eb59d8a6c7d5035355f03b903b84700376f0efa23f3b095815776c5c6daf2b371a0a61b5f703451b"
+ * );
+ * // isCorrect = true
  */
 async function isSignatureCorrect(
   provider: Provider,
@@ -1041,6 +1254,7 @@ async function isSignatureCorrect(
  * @example
  *
  * import { Wallet, utils, Provider } from "zksync-ethers";
+ * import { ethers } from "ethers";
  *
  * const ADDRESS = "<WALLET_ADDRESS>";
  * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -1077,6 +1291,7 @@ export async function isMessageSignatureCorrect(
  * @example
  *
  * import { Wallet, utils, Provider, EIP712Signer } from "zksync-ethers";
+ * import { ethers } from "ethers";
  *
  * const ADDRESS = "<WALLET_ADDRESS>";
  * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
@@ -1097,7 +1312,14 @@ export async function isMessageSignatureCorrect(
  *
  * const signature = await eip712Signer.sign(tx);
  *
- * const isValidSignature = await utils.isTypedDataSignatureCorrect(provider, ADDRESS, await eip712Signer.getDomain(), utils.EIP712_TYPES, EIP712Signer.getSignInput(tx), signature);
+ * const isValidSignature = await utils.isTypedDataSignatureCorrect(
+ *  provider,
+ *  ADDRESS,
+ *  await eip712Signer.getDomain(),
+ *  utils.EIP712_TYPES,
+ *  EIP712Signer.getSignInput(tx),
+ *  signature
+ * );
  * // isValidSignature = true
  */
 export async function isTypedDataSignatureCorrect(
@@ -1116,7 +1338,7 @@ export async function isTypedDataSignatureCorrect(
  * Returns an estimation of the L2 gas required for token bridging via the default ERC20 bridge.
  *
  * @param providerL1 The Ethers provider for the L1 network.
- * @param providerL2 The zkSync provider for the L2 network.
+ * @param providerL2 The ZKsync provider for the L2 network.
  * @param token The address of the token to be bridged.
  * @param amount The deposit amount.
  * @param to The recipient address on the L2 network.
@@ -1128,7 +1350,28 @@ export async function isTypedDataSignatureCorrect(
  *
  * @example
  *
+ * import { Provider, utils, types } from "zksync-ethers";
+ * import { ethers } from "ethers";
  *
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ * const ethProvider = ethers.getDefaultProvider("sepolia");
+ *
+ * const token = "0x0000000000000000000000000000000000000001";
+ * const amount = 5;
+ * const to = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const from = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const gasPerPubdataByte = utils.REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT;
+ *
+ * const gas = await utils.estimateCustomBridgeDepositL2Gas(
+ *   ethProvider,
+ *   provider,
+ *   token,
+ *   amount,
+ *   to,
+ *   from,
+ *   gasPerPubdataByte
+ * );
+ * // gas = 355_704
  */
 export async function estimateDefaultBridgeDepositL2Gas(
   providerL1: ethers.Provider,
@@ -1184,6 +1427,8 @@ export async function estimateDefaultBridgeDepositL2Gas(
  *
  * @example
  *
+ * import { utils } from "zksync-ethers";
+ *
  * const scaledGasLimit = utils.scaleGasLimit(10_000);
  * // scaledGasLimit = 12_000
  */
@@ -1197,7 +1442,7 @@ export function scaleGasLimit(gasLimit: bigint): bigint {
 /**
  * Returns an estimation of the L2 gas required for token bridging via the custom ERC20 bridge.
  *
- * @param providerL2 The zkSync provider for the L2 network.
+ * @param providerL2 The ZKsync provider for the L2 network.
  * @param l1BridgeAddress The address of the custom L1 bridge.
  * @param l2BridgeAddress The address of the custom L2 bridge.
  * @param token The address of the token to be bridged.
@@ -1213,7 +1458,40 @@ export function scaleGasLimit(gasLimit: bigint): bigint {
  *
  * @example
  *
+ * import { Provider, utils, types } from "zksync-ethers";
  *
+ * const provider = Provider.getDefaultProvider(types.Network.Sepolia);
+ *
+ * const l1BridgeAddress = "0x3e8b2fe58675126ed30d0d12dea2a9bda72d18ae";
+ * const l2BridgeAddress = "0x681a1afdc2e06776816386500d2d461a6c96cb45";
+ * const token = "0x56E69Fa1BB0d1402c89E3A4E3417882DeA6B14Be";
+ * const amount = 5;
+ * const to = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const bridgeData = "0x00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000
+ * 0000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000016000000000000000000000
+ * 000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000
+ * 000000000000000000000000000000000000000000000000000000543726f776e0000000000000000000000000000000000000000000000000000
+ * 000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000
+ * 0000000000020000000000000000000000000000000000000000000000000000000000000000543726f776e000000000000000000000000000000
+ * 000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000
+ * 00000000000000000000000000000000012";
+ * const from = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const gasPerPubdataByte = utils.REQUIRED_L1_TO_L2_GAS_PER_PUBDATA_LIMIT;
+ * const l2Value = 0;
+ *
+ * const gas = await utils.estimateCustomBridgeDepositL2Gas(
+ *   provider,
+ *   l1BridgeAddress,
+ *   l2BridgeAddress,
+ *   token,
+ *   amount,
+ *   to,
+ *   bridgeData,
+ *   from,
+ *   gasPerPubdataByte,
+ *   l2Value
+ * );
+ * // gas = 683_830
  */
 export async function estimateCustomBridgeDepositL2Gas(
   providerL2: Provider,
@@ -1247,6 +1525,13 @@ export async function estimateCustomBridgeDepositL2Gas(
  * Creates a JSON string from an object, including support for serializing bigint types.
  *
  * @param object The object to serialize to JSON.
+ *
+ * @example
+ *
+ * import { utils } from "zksync-ethers";
+ *
+ * const json = utils.toJSON({gasLimit: 1_000n})
+ * // {"gasLimit": 1000}
  */
 export function toJSON(object: any): string {
   return JSON.stringify(
@@ -1268,6 +1553,15 @@ export function toJSON(object: any): string {
  * @param a - The first address to compare.
  * @param b - The second address to compare.
  * @returns A boolean indicating whether the addresses are equal.
+ *
+ * @example
+ *
+ * import { utils } from "zksync-ethers";
+ *
+ * const address1 = "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049";
+ * const address2 = "0x36615cf349d7f6344891b1e7ca7c72883f5dc049";
+ * const isEqual = utils.isAddressEq(address1, address2);
+ * // true
  */
 export function isAddressEq(a: Address, b: Address): boolean {
   return a.toLowerCase() === b.toLowerCase();

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -32,7 +32,7 @@ import {
 } from './typechain';
 
 /**
- * A `Wallet` is an extension of {@link ethers.Wallet} with additional features for interacting with zkSync Era.
+ * A `Wallet` is an extension of {@link ethers.Wallet} with additional features for interacting with ZKsync Era.
  * It facilitates bridging assets between different networks.
  * All transactions must originate from the address corresponding to the provided private key.
  */
@@ -1078,6 +1078,7 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    * @example Transfer ETH.
    *
    * import { Wallet, Provider, types } from "zksync-ethers";
+   * import { ethers } from "ethers";
    *
    * const PRIVATE_KEY = "<WALLET_PRIVATE_KEY>";
    *

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -112,6 +112,13 @@ describe('Provider', () => {
     }).timeout(5_000);
   });
 
+  describe("#getConfirmedTokens()", () => {
+    it("should return confirmed tokens", async () => {
+      const result = await provider.getConfirmedTokens();
+      expect(result).to.have.lengthOf(1);
+    });
+  });
+
   describe('#getAllAccountBalances()', () => {
     it('should return the all balances of the account at `address`', async () => {
       const result = await provider.getAllAccountBalances(ADDRESS1);

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -46,6 +46,13 @@ describe('Provider', () => {
     });
   });
 
+  describe('#getProtocolVersion()', () => {
+    it('should return the latest protocol version', async () => {
+      const result = await provider.getProtocolVersion();
+      expect(result).not.to.be.null;
+    });
+  });
+
   describe('#getMainContractAddress()', () => {
     it('should return the address of main contract', async () => {
       const result = await provider.getMainContractAddress();

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -913,4 +913,16 @@ describe('Provider', () => {
       expect(result).not.to.be.null;
     }).timeout(10_000);
   });
+
+  describe('#sendRawTransactionWithDetailedOutput()', () => {
+    it('should return the transaction with detailed output', async () => {
+      const result = await provider.sendRawTransactionWithDetailedOutput(
+        await wallet.signTransaction({
+          to: ADDRESS2,
+          value: 7_000_000_000n
+        })
+      )
+      expect(result).not.to.be.null;
+    }).timeout(10_000);
+  });
 });

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -53,6 +53,13 @@ describe('Provider', () => {
     });
   });
 
+  describe('#getFeeParams()', () => {
+    it('should return the current fee parameters', async () => {
+      const result = await provider.getFeeParams();
+      expect(result).not.to.be.null;
+    });
+  });
+
   describe('#getMainContractAddress()', () => {
     it('should return the address of main contract', async () => {
       const result = await provider.getMainContractAddress();

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -126,8 +126,8 @@ describe('Provider', () => {
     }).timeout(5_000);
   });
 
-  describe("#getConfirmedTokens()", () => {
-    it("should return confirmed tokens", async () => {
+  describe('#getConfirmedTokens()', () => {
+    it('should return confirmed tokens', async () => {
       const result = await provider.getConfirmedTokens();
       expect(result).to.have.lengthOf(1);
     });
@@ -919,9 +919,9 @@ describe('Provider', () => {
       const result = await provider.sendRawTransactionWithDetailedOutput(
         await wallet.signTransaction({
           to: ADDRESS2,
-          value: 7_000_000_000n
+          value: 7_000_000_000n,
         })
-      )
+      );
       expect(result).not.to.be.null;
     }).timeout(10_000);
   });

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -353,4 +353,56 @@ describe('utils', () => {
       expect(result).to.be.deep.equal(tx);
     });
   });
+
+  describe('#eip712TxHash()', () => {
+    it('should create a hash by using Ethereum signature', async () => {
+      const tx: types.TransactionRequest = {
+        chainId: 270n,
+        from: ADDRESS1,
+        to: ADDRESS2,
+        value: 1_000_000n,
+      };
+      const signature = ethers.Signature.from(
+        '0x73a20167b8d23b610b058c05368174495adf7da3a4ed4a57eb6dbdeb1fafc24aaf87530d663a0d061f69bb564d2c6fb46ae5ae776bbd4bd2a2a4478b9cd1b42a'
+      );
+      const hash =
+        '0x8efdc7ce5f5a75ab945976c3e2b0c2a45e9f8e15ff940d05625ac5545cd9f870';
+
+      const result = utils.eip712TxHash(tx, signature);
+      expect(result).to.be.equal(hash);
+    });
+
+    it('should create a hash by using custom signature in the transaction', async () => {
+      const tx: types.TransactionRequest = {
+        type: 113,
+        nonce: 0,
+        maxPriorityFeePerGas: 0n,
+        maxFeePerGas: 0n,
+        gasLimit: 0n,
+        to: ADDRESS2,
+        value: 1_000_000n,
+        data: '0x',
+        chainId: 270n,
+        from: ADDRESS1,
+        customData: {
+          gasPerPubdata: 50_000n,
+          factoryDeps: [],
+          customSignature:
+            '0x307837373262396162343735386435636630386637643732303161646332653534383933616532376263666562323162396337643666643430393766346464653063303166376630353332323866346636643838653662663334333436343931343135363761633930363632306661653832633239333339393062353563613336363162',
+          paymasterParams: {
+            paymaster: '0xa222f0c183AFA73a8Bc1AFb48D34C88c9Bf7A174',
+            paymasterInput: ethers.getBytes(
+              '0x949431dc000000000000000000000000841c43fa5d8fffdb9efe3358906f7578d8700dd4000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000'
+            ),
+          },
+        },
+      };
+
+      const hash =
+        '0xc0ba55587423e1ef281b06a9d684b481365897f37a6ad611d7619b1b7e0bc908';
+
+      const result = utils.eip712TxHash(tx);
+      expect(result).to.be.equal(hash);
+    });
+  });
 });


### PR DESCRIPTION
# What :computer: 
* Add new rpc endpoints to `Provider` class.
* Add missing examples.