### PR TITLE
fix: make weth bridge addresses optional

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# This CODEOWNERS file sets the individuals responsible for code in the zksync2-js JavaScript SDK repository.
+# This CODEOWNERS file sets the individuals responsible for code in the zksync-ethers JavaScript SDK repository.
 
 # These users are the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,18 +2,18 @@
 
 ## Welcome! 👋
 
-Hello there, contributor! We're delighted that you're considering contributing to the `zksync2-js` project. This document is here to guide you through the steps and best practices for contributing to this JavaScript-based repository.
+Hello there, contributor! We're delighted that you're considering contributing to the `zksync-ethers` project. This document is here to guide you through the steps and best practices for contributing to this JavaScript-based repository.
 
 Please take a moment to review this document to ensure a smooth and efficient contribution process for everyone involved.
 
 ## Getting Started
 
-- **Fork the repository.** Begin by forking the main `zksync2-js` repository to your personal GitHub account.
+- **Fork the repository.** Begin by forking the main `zksync-ethers` repository to your personal GitHub account.
 
 - **Clone the repository.** After forking, clone the repository to your local machine:
 
 ```bash
-git clone https://github.com/<your-github-username>/zksync2-js.git
+git clone https://github.com/<your-github-username>/zksync-ethers.git
 ```
 
 - **Create a new branch.** Use descriptive names for your branches to help identify the feature, bugfix, or enhancement you're addressing:
@@ -45,7 +45,7 @@ git push origin feature/description-of-your-feature
 
 ## Submitting a Pull Request
 
-- **Initiate a pull request (PR).** Go to the main `zksync2-js` repository. Your recently pushed branch should be highlighted, showing a "Compare & pull request" button. Click on it and provide a clear, detailed description of your changes in the PR.
+- **Initiate a pull request (PR).** Go to the main `zksync-ethers` repository. Your recently pushed branch should be highlighted, showing a "Compare & pull request" button. Click on it and provide a clear, detailed description of your changes in the PR.
 
 - **Await a review.** Our maintainers will review your PR. They might request changes or clarifications, so be ready to address any feedback.
 
@@ -66,7 +66,7 @@ If you're unsure about something or have questions, don't hesitate to open an is
 
 ## What's Next?
 
-Once your PR is approved and merged, your contribution will be integrated into the `zksync2-js` repository. Congratulations, and thank you! We value your contribution and look forward to future collaborations.
+Once your PR is approved and merged, your contribution will be integrated into the `zksync-ethers` repository. Congratulations, and thank you! We value your contribution and look forward to future collaborations.
 
 Remember, the best contributions come from enjoying the process, being respectful, and continuously learning. Thanks for being a part of our community!
 

--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -124,7 +124,7 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
           this._signerL1()
         ),
         weth: IL1ERC20Bridge__factory.connect(
-          addresses.wethL1,
+          addresses.wethL1 || addresses.erc20L1,
           this._signerL1()
         ),
         shared: IL1SharedBridge__factory.connect(
@@ -1906,7 +1906,7 @@ export function AdapterL2<TBase extends Constructor<TxSender>>(Base: TBase) {
       const addresses = await this._providerL2().getDefaultBridgeAddresses();
       return {
         erc20: IL2Bridge__factory.connect(addresses.erc20L2, this._signerL2()),
-        weth: IL2Bridge__factory.connect(addresses.wethL2, this._signerL2()),
+        weth: IL2Bridge__factory.connect(addresses.wethL2 || addresses.erc20L2, this._signerL2()),
         shared: IL2SharedBridge__factory.connect(
           addresses.sharedL2,
           this._signerL2()


### PR DESCRIPTION
# What :computer: 
Use erc20 bridge addresses if weth bridge addresses are not present.

# Why :hand:
Currently weth bridge addresses are required, and `getL1BridgeContracts`/`getL2BridgeContracts` function fails.

# Notes :memo:
This should fix deposits to the chains with custom base token.
