### PR TITLE
fix: make weth bridge addresses optional

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -117,7 +117,10 @@ export function AdapterL1<TBase extends Constructor<TxSender>>(Base: TBase) {
           addresses.erc20L1,
           this._signerL1()
         ),
-        weth: IL1ERC20BridgeFactory.connect(addresses.wethL1, this._signerL1()),
+        weth: IL1ERC20BridgeFactory.connect(
+          addresses.wethL1 || addresses.erc20L1,
+          this._signerL1()
+        ),
         shared: IL1SharedBridgeFactory.connect(
           addresses.sharedL1,
           this._signerL1()
@@ -1876,7 +1879,10 @@ export function AdapterL2<TBase extends Constructor<TxSender>>(Base: TBase) {
       const addresses = await this._providerL2().getDefaultBridgeAddresses();
       return {
         erc20: IL2BridgeFactory.connect(addresses.erc20L2, this._signerL2()),
-        weth: IL2BridgeFactory.connect(addresses.wethL2, this._signerL2()),
+        weth: IL2BridgeFactory.connect(
+          addresses.wethL2 || addresses.erc20L2,
+          this._signerL2()
+        ),
         shared: Il2SharedBridgeFactory.connect(
           addresses.sharedL2,
           this._signerL2()

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,7 +167,6 @@ export interface TransactionWithDetailedOutput {
   }>;
 }
 
-
 /** Represents a message proof.
  *  @deprecated In favor of {@link LogProof}.
  */


### PR DESCRIPTION
# What :computer: 
Use erc20 bridge addresses if weth bridge addresses are not present.



# Why :hand:
Currently weth bridge addresses are required, and getL1BridgeContracts/getL2BridgeContracts function fails.

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
This should fix deposits to the chains with custom base token.
