### PR TITLE
set value of sideEffects to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
What 💻
Set the value of option "sideEffects" in package.json to false.
Same as what ethers.js does: https://github.com/ethers-io/ethers.js/blob/main/package.json

Why ✋
There are bundled frontend applications that use zksync-ethers. This option will enable tree shaking. Bundles can be organized more efficiently, and in most cases less code will be fetched and parsed by clients, so performance can be improved.

Evidence 📷
Find more about the option here: https://webpack.js.org/guides/tree-shaking/#clarifying-tree-shaking-and-sideeffects