### PR TITLE
fix: include custom signature in estimateGas calls

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1281,6 +1281,9 @@ export function JsonRpcApiProvider<
             Array.from(ethers.getBytes(dep))
         );
       }
+      if (tx.customData.customSignature) {
+        result.eip712Meta.customSignature = Array.from(ethers.getBytes(tx.customData.customSignature));
+      }
       if (tx.customData.paymasterParams) {
         result.eip712Meta.paymasterParams = {
           paymaster: ethers.hexlify(tx.customData.paymasterParams.paymaster),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1282,7 +1282,9 @@ export function JsonRpcApiProvider<
         );
       }
       if (tx.customData.customSignature) {
-        result.eip712Meta.customSignature = Array.from(ethers.getBytes(tx.customData.customSignature));
+        result.eip712Meta.customSignature = Array.from(
+          ethers.getBytes(tx.customData.customSignature)
+        );
       }
       if (tx.customData.paymasterParams) {
         result.eip712Meta.paymasterParams = {


### PR DESCRIPTION
# What :computer: 

Include `customData.customSignature` in `estimateGas` calls.

# Why :hand:

Without it, it is very hard to properly estimate gas for AA accounts with complex validation logic. But also, there is no reason not to include it, I don't know why it was omitted before.

# Evidence :camera:

Correctly estimated gas for AA with complex validation logic:

![image](https://github.com/user-attachments/assets/9af8968f-9234-44a8-afcc-2886c624c9a1)


# Notes :memo:


