### PR TITLE
ci: fix running workflow without approval

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,11 +8,6 @@ on:
         default: ""
         required: false
 
-  workflow_run:
-    workflows: ["Publish NPM package"]
-    types:
-      - completed
-
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,36 @@ jobs:
           npm run types
           npm run build
           npm publish --tag ${{ inputs.tag }} 
+
+  docs-build:
+    name: Build TypeDoc Documentation
+    runs-on: ubuntu-latest
+    needs: zksync
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: yarn install
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Generate documentation
+        run: yarn docs
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  docs-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: docs-build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# What :computer: 
* Workflow for publishing docs (`docs.yml`) could be run from user outside of collaborators without approval. The following PR fixes it.
* The publishing docs is added to workflow that publish the package to NPM in order to automate the docs publishing after successful package publishing.  
