### PR TITLE
ci: fix permissions for publishing docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,16 +18,9 @@ jobs:
     name: Build TypeDoc Documentation
     runs-on: ubuntu-latest
     steps:
-      - name: Determine ref
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "REF=${{ inputs.ref }}" >> $GITHUB_ENV
-          else
-            echo "REF=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
-          fi
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.REF }}
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,10 @@ jobs:
           npm publish --tag ${{ inputs.tag }} 
 
   docs-build:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     name: Build TypeDoc Documentation
     runs-on: ubuntu-latest
     needs: zksync
@@ -60,6 +64,10 @@ jobs:
           path: docs
 
   docs-deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
# What :computer: 
* Add the permissions for publishing docs in `publish` workflow.
* Use only `inputs.ref` in `docs` workflow.