### PR TITLE
feat: interop support

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -27,8 +27,6 @@ import {
   IL2NativeTokenVault__factory,
   IL2SharedBridge,
   IL2SharedBridge__factory,
-  IBridgedStandardToken,
-  IBridgedStandardToken__factory,
 } from './typechain';
 import {
   Address,
@@ -55,6 +53,7 @@ import {
   ProtocolVersion,
   FeeParams,
   TransactionWithDetailedOutput,
+  InteropMode,
 } from './types';
 import {
   getL2HashFromPriorityOp,
@@ -352,14 +351,17 @@ export function JsonRpcApiProvider<
      *
      * @param txHash The hash of the L2 transaction the L2 to L1 log was produced within.
      * @param [index] The index of the L2 to L1 log in the transaction.
+     * @param [interopMode] Interop mode for interop, target Merkle root for the proof.
      */
     async getLogProof(
       txHash: BytesLike,
-      index?: number
+      index?: number,
+      interopMode?: InteropMode
     ): Promise<LogProof | null> {
       return await this.send('zks_getL2ToL1LogProof', [
         ethers.hexlify(txHash),
         index,
+        interopMode,
       ]);
     }
 
@@ -1656,9 +1658,10 @@ export class Provider extends JsonRpcApiProvider(ethers.JsonRpcProvider) {
    */
   override async getLogProof(
     txHash: BytesLike,
-    index?: number
+    index?: number,
+    interopMode?: InteropMode
   ): Promise<LogProof | null> {
-    return super.getLogProof(txHash, index);
+    return super.getLogProof(txHash, index, interopMode);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,11 @@ export type DeploymentType =
   | 'create2'
   | 'create2Account';
 
+/** Interop modes are used to specify the target Merkle root for interop log proofs */
+export type InteropMode =
+  /** Proof-based interop on Gateway, meaning the Merkle proof hashes to Gateway's MessageRoot */
+  'proof_based_gw';
+
 /** Bridged token. */
 export interface Token {
   /** Token address on L1. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1671,3 +1671,41 @@ export function encodeNativeTokenVaultTransferData(
 
   return ethers.concat(['0x01', data]);
 }
+
+export function encodeNTVAssetId(chainId: bigint, address: string) {
+  const abi = new AbiCoder();
+  const hex = abi.encode(
+    ['uint256', 'address', 'address'],
+    [chainId, L2_NATIVE_TOKEN_VAULT_ADDRESS, address]
+  );
+  return ethers.keccak256(hex);
+}
+
+export async function ethAssetId(provider: ethers.Provider) {
+  const network = await provider.getNetwork();
+
+  return encodeNTVAssetId(network.chainId, ETH_ADDRESS_IN_CONTRACTS);
+}
+
+interface WithToken {
+  token: Address;
+}
+
+interface WithAssetId {
+  assetId: BytesLike;
+}
+
+// For backwards compatibility and easier interface lots of methods
+// will continue to allow providing either token or assetId
+export type WithTokenOrAssetId = WithToken | WithAssetId;
+
+export function encodeNTVTransferData(
+  amount: bigint,
+  receiver: Address,
+  token: Address
+) {
+  return new AbiCoder().encode(
+    ['uint256', 'address', 'address'],
+    [amount, receiver, token]
+  );
+}

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -17,6 +17,7 @@ import {
   FinalizeL1DepositParams,
   FinalizeWithdrawalParams,
   FullDepositFee,
+  InteropMode,
   PaymasterParams,
   PriorityOpResponse,
   TransactionLike,
@@ -701,9 +702,14 @@ export class Wallet extends AdapterL2(AdapterL1(ethers.Wallet)) {
    */
   override async getFinalizeWithdrawalParams(
     withdrawalHash: BytesLike,
-    index = 0
+    index = 0,
+    interopMode?: InteropMode
   ): Promise<FinalizeWithdrawalParams> {
-    return super.getFinalizeWithdrawalParams(withdrawalHash, index);
+    return super.getFinalizeWithdrawalParams(
+      withdrawalHash,
+      index,
+      interopMode
+    );
   }
 
   override async getFinalizeDepositParams(

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -107,6 +107,7 @@ async function sendTokenToL2(l1TokenAddress: string) {
     approveBaseERC20: true,
     refundRecipient: await wallet.getAddress(),
   });
+  console.log(`Deposit tx: ${priorityOpResponse.hash}`);
   const receipt = await priorityOpResponse.waitFinalize();
   console.log(`Send funds tx: ${receipt.hash}`);
 }
@@ -142,6 +143,7 @@ async function main() {
   console.log(`L2 base token balance before: ${await wallet.getBalance()}`);
 
   await mintTokensOnL1(baseToken);
+  console.log('Minted tokens on L1', baseToken);
   await sendTokenToL2(baseToken);
 
   console.log(

--- a/tests/tokens.json
+++ b/tests/tokens.json
@@ -1,0 +1,4 @@
+{
+  "l1Address": "0x5E6D086F5eC079ADFF4FB3774CDf3e8D6a34F7E9",
+  "l2Address": "0xb1fa7e7603ca3fa9584a677cd7Ea7d651cDcCcFA"
+}


### PR DESCRIPTION
# What :computer: reduced interop support for v29

Adds interop support by modifying the existing `getLogProof` to accept an additional parameter, `interopMode`, to specify the target Merkle root for the interop Merkle proof. This is done in a backwards-compatible way while also ensuring future interop modes (proof based on L1, commit based, ...) can be easily added.

This PR is associated with: https://github.com/matter-labs/zksync-era/pull/4130

# Why :hand:
* Reason why first thing was added to PR
* Reason why second thing was added to PR
* Reason why third thing was added to PR

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?
