### PR TITLE
feat: deprecate legacy `zks` methods

### DIFF
--- a/src/adapters.ts
+++ b/src/adapters.ts
@@ -2138,6 +2138,10 @@ export function AdapterL2<TBase extends Constructor<TxSender>>(Base: TBase) {
     }
 
     /**
+     * @deprecated JSON-RPC endpoint has been removed. Use `addresstokenbalance` method from the block explorer API
+     *  ({@link https://block-explorer-api.mainnet.zksync.io/docs#/Account%20API/ApiController_getAccountTokenHoldings})
+     *  or other token APIs from providers like Alchemy or QuickNode.
+     *
      * Returns all token balances of the account.
      */
     async getAllBalances(): Promise<BalancesMap> {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -584,6 +584,8 @@ export function JsonRpcApiProvider<
     }
 
     /**
+     * @deprecated JSON-RPC endpoint has been removed. Use third-party APIs such as Coingecko or {@link https://tokenlists.org}.
+     *
      * Returns confirmed tokens. Confirmed token is any token bridged to ZKsync Era via the official bridge.
      *
      * Calls the {@link https://docs.zksync.io/build/api.html#zks_getconfirmedtokens zks_getConfirmedTokens} JSON-RPC method.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -711,6 +711,8 @@ export function JsonRpcApiProvider<
     }
 
     /**
+     * @deprecated JSON-RPC endpoint has been destabilized and is now available as `unstable_sendRawTransactionWithDetailedOutput`.
+     *
      * Executes a transaction and returns its hash, storage logs, and events that would have been generated if the
      * transaction had already been included in the block. The API has a similar behaviour to `eth_sendRawTransaction`
      * but with some extra data returned from it.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -291,6 +291,8 @@ export function JsonRpcApiProvider<
     }
 
     /**
+     * @deprecated JSON-RPC endpoint has been removed. Use `eth_protocolVersion` to fetch current protocol semantic version.
+     *
      * Return the protocol version.
      *
      * Calls the {@link https://docs.zksync.io/build/api.html#zks_getprotocolversion zks_getProtocolVersion} JSON-RPC method.

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -563,6 +563,10 @@ export function JsonRpcApiProvider<
     }
 
     /**
+     * @deprecated JSON-RPC endpoint has been removed. Use `addresstokenbalance` method from the block explorer API
+     *  ({@link https://block-explorer-api.mainnet.zksync.io/docs#/Account%20API/ApiController_getAccountTokenHoldings})
+     *  or other token APIs from providers like Alchemy or QuickNode.
+     *
      * Returns all balances for confirmed tokens given by an account address.
      *
      * Calls the {@link https://docs.zksync.io/build/api.html#zks-getallaccountbalances zks_getAllAccountBalances} JSON-RPC method.

--- a/src/smart-account.ts
+++ b/src/smart-account.ts
@@ -182,6 +182,10 @@ export class SmartAccount extends AbstractSigner {
   }
 
   /**
+   * @deprecated Underlying JSON-RPC endpoint has been removed. Use `addresstokenbalance` method from the block explorer API
+   *  ({@link https://block-explorer-api.mainnet.zksync.io/docs#/Account%20API/ApiController_getAccountTokenHoldings})
+   *  or other token APIs from providers like Alchemy or QuickNode.
+   *
    * Returns all token balances of the account.
    *
    * @example


### PR DESCRIPTION
# What :computer: 
Deprecates a few legacy methods from `zks` namespace that are about to be removed

# Why :hand:
After analyzing usefulness and usage patterns we decided to remove some of them methods from `zks` namespace