### PR TITLE
feat: avoid `zks_estimateFee` for populating fee data

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -74,6 +74,7 @@ import {
   L2_NATIVE_TOKEN_VAULT_ADDRESS,
   encodeNativeTokenVaultTransferData,
   encodeNativeTokenVaultAssetId,
+  DEFAULT_GAS_PER_PUBDATA_LIMIT,
 } from './utils';
 import {Signer} from './signer';
 
@@ -342,6 +343,18 @@ export function JsonRpcApiProvider<
     async getGasPrice(): Promise<bigint> {
       const feeData = await this.getFeeData();
       return feeData.gasPrice!;
+    }
+
+    /**
+     * Returns an estimate (best guess) of the gas per pubdata to use in a transaction.
+     */
+    async getGasPerPubdata(): Promise<bigint> {
+      return await this.send('zks_gasPerPubdata', []).catch(_ => {
+        // Presuming `zks_gasPerPubdata` is not available on this environment yet.
+        // Using default value.
+        // TODO: Remove this workaround when all chains have been upgraded
+        return BigInt(DEFAULT_GAS_PER_PUBDATA_LIMIT);
+      });
     }
 
     /**


### PR DESCRIPTION
# What :computer: 
This PR replaces all usages of `zks_estimateFee` in favour of `eth_estimateGas` + `eth_gasPrice` + `zks_gasPerPubdata` (new method, won't be available on _all_ envs for a bit).

# Why :hand:
Benefit of this is that we won't wait for gas limit to be estimated if all we want is just current gas price or gas per pubdata.

Also, `zks_estimateFee` is scheduled for deprecation soon so its important to start reducing its usage.
