### PR TITLE
fix: use onchain data instead of RPC endpoints

### DIFF
--- a/abi/IBridgehub.json
+++ b/abi/IBridgehub.json
@@ -4,6 +4,194 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetInfo",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_assetAddress",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "additionalData",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "AssetRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "BaseTokenAssetIdRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BridgeBurn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BridgeMint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "chainTypeManager",
+        "type": "address"
+      }
+    ],
+    "name": "ChainTypeManagerAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "chainTypeManager",
+        "type": "address"
+      }
+    ],
+    "name": "ChainTypeManagerRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "zkChain",
+        "type": "address"
+      }
+    ],
+    "name": "MigrationFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "settlementLayerChainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MigrationStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "oldAdmin",
         "type": "address"
@@ -30,7 +218,7 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "stateTransitionManager",
+        "name": "chainTypeManager",
         "type": "address"
       },
       {
@@ -63,6 +251,38 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "isWhitelisted",
+        "type": "bool"
+      }
+    ],
+    "name": "SettlementLayerRegistered",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "L1_CHAIN_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "acceptAdmin",
     "outputs": [],
@@ -73,11 +293,11 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_stateTransitionManager",
+        "name": "_chainTypeManager",
         "type": "address"
       }
     ],
-    "name": "addStateTransitionManager",
+    "name": "addChainTypeManager",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -85,14 +305,59 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "_baseTokenAssetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "addTokenAssetId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [
+      {
         "internalType": "address",
-        "name": "_token",
+        "name": "",
         "type": "address"
       }
     ],
-    "name": "addToken",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_baseTokenAssetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assetIdIsRegistered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "assetRouter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -120,16 +385,163 @@
         "internalType": "uint256",
         "name": "_chainId",
         "type": "uint256"
+      }
+    ],
+    "name": "baseTokenAssetId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_msgValue",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
       },
       {
         "internalType": "address",
-        "name": "_stateTransitionManager",
+        "name": "_originalCaller",
         "type": "address"
       },
       {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "bridgeBurn",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "_bridgeMintData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "bridgeMint",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
         "internalType": "address",
-        "name": "_baseToken",
+        "name": "_depositSender",
         "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "bridgeRecoverFailedTransfer",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "chainTypeManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_chainTypeManager",
+        "type": "address"
+      }
+    ],
+    "name": "chainTypeManagerIsRegistered",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_chainTypeManager",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_baseTokenAssetId",
+        "type": "bytes32"
       },
       {
         "internalType": "uint256",
@@ -145,6 +557,11 @@
         "internalType": "bytes",
         "name": "_initData",
         "type": "bytes"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_factoryDeps",
+        "type": "bytes[]"
       }
     ],
     "name": "createNewChain",
@@ -161,6 +578,112 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_ctmAddress",
+        "type": "address"
+      }
+    ],
+    "name": "ctmAssetIdFromAddress",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ctmAssetIdFromChainId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_assetInfo",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ctmAssetIdToAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_canonicalTxHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_expirationTimestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "forwardTransactionOnGateway",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllZKChainChainIDs",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllZKChains",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_chainId",
         "type": "uint256"
@@ -170,6 +693,38 @@
     "outputs": [
       {
         "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getZKChain",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1CtmDeployer",
+    "outputs": [
+      {
+        "internalType": "contract ICTMDeploymentTracker",
         "name": "",
         "type": "address"
       }
@@ -209,6 +764,39 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "messageRoot",
+    "outputs": [
+      {
+        "internalType": "contract IMessageRoot",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "migrationPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauseMigration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -390,12 +978,61 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
         "internalType": "address",
-        "name": "_stateTransitionManager",
+        "name": "_hyperchain",
         "type": "address"
       }
     ],
-    "name": "removeStateTransitionManager",
+    "name": "registerAlreadyDeployedZKChain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "registerLegacyChain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newSettlementLayerChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isWhitelisted",
+        "type": "bool"
+      }
+    ],
+    "name": "registerSettlementLayer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_chainTypeManager",
+        "type": "address"
+      }
+    ],
+    "name": "removeChainTypeManager",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -536,6 +1173,47 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_sharedBridge",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ICTMDeploymentTracker",
+        "name": "_l1CtmDeployer",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IMessageRoot",
+        "name": "_messageRoot",
+        "type": "address"
+      }
+    ],
+    "name": "setAddresses",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_additionalData",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_assetAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setCTMAssetAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_newPendingAdmin",
         "type": "address"
       }
@@ -548,14 +1226,20 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_sharedBridge",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
       }
     ],
-    "name": "setSharedBridge",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "name": "settlementLayer",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -563,12 +1247,19 @@
     "name": "sharedBridge",
     "outputs": [
       {
-        "internalType": "contract IL1SharedBridge",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpauseMigration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -579,45 +1270,7 @@
         "type": "uint256"
       }
     ],
-    "name": "stateTransitionManager",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_stateTransitionManager",
-        "type": "address"
-      }
-    ],
-    "name": "stateTransitionManagerIsRegistered",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_baseToken",
-        "type": "address"
-      }
-    ],
-    "name": "tokenIsRegistered",
+    "name": "whitelistedSettlementLayers",
     "outputs": [
       {
         "internalType": "bool",

--- a/abi/IL1AssetRouter.json
+++ b/abi/IL1AssetRouter.json
@@ -1,114 +1,28 @@
 [
   {
+    "anonymous": false,
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_l1WethAddress",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_bridgehub",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_l1Nullifier",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_eraChainId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "_eraDiamondProxy",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "addr",
-        "type": "address"
-      }
-    ],
-    "name": "AddressAlreadyUsed",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
+        "indexed": true,
         "internalType": "bytes32",
         "name": "assetId",
         "type": "bytes32"
-      }
-    ],
-    "name": "AssetHandlerDoesNotExist",
-    "type": "error"
-  },
-  {
-    "inputs": [
+      },
       {
+        "indexed": true,
         "internalType": "bytes32",
-        "name": "assetId",
+        "name": "additionalData",
         "type": "bytes32"
-      }
-    ],
-    "name": "AssetIdNotSupported",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "NotInitializedReentrancyGuard",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "Reentrancy",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "SlotOccupied",
-    "type": "error"
-  },
-  {
-    "inputs": [
+      },
       {
+        "indexed": false,
         "internalType": "address",
-        "name": "token",
+        "name": "assetDeploymentTracker",
         "type": "address"
       }
     ],
-    "name": "TokenNotSupported",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
-      }
-    ],
-    "name": "Unauthorized",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "UnsupportedEncodingVersion",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ZeroAddress",
-    "type": "error"
+    "name": "AssetDeploymentTrackerRegistered",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -147,42 +61,11 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "_assetAddress",
+        "name": "_assetHandlerAddress",
         "type": "address"
       }
     ],
     "name": "AssetHandlerRegistered",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "assetId",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "assetHandlerAddress",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "additionalData",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "assetDeploymentTracker",
-        "type": "address"
-      }
-    ],
-    "name": "AssetHandlerRegisteredInitial",
     "type": "event"
   },
   {
@@ -376,19 +259,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "version",
-        "type": "uint8"
-      }
-    ],
-    "name": "Initialized",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": true,
         "internalType": "uint256",
         "name": "chainId",
@@ -415,7 +285,7 @@
       {
         "indexed": false,
         "internalType": "address",
-        "name": "l1Asset",
+        "name": "l1Token",
         "type": "address"
       },
       {
@@ -429,70 +299,6 @@
     "type": "event"
   },
   {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferStarted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "Paused",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "Unpaused",
-    "type": "event"
-  },
-  {
     "inputs": [],
     "name": "BRIDGE_HUB",
     "outputs": [
@@ -500,32 +306,6 @@
         "internalType": "contract IBridgehub",
         "name": "",
         "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ERA_CHAIN_ID",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "L1_CHAIN_ID",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -558,36 +338,10 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "acceptOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "assetId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "assetDeploymentTracker",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "assetDeploymentTracker",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "assetId",
+        "name": "_assetId",
         "type": "bytes32"
       }
     ],
@@ -595,7 +349,7 @@
     "outputs": [
       {
         "internalType": "address",
-        "name": "assetHandlerAddress",
+        "name": "",
         "type": "address"
       }
     ],
@@ -798,59 +552,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "_chainId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "_depositSender",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_l1Token",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_amount",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "_l2TxHash",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_l2BatchNumber",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_l2MessageIndex",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint16",
-        "name": "_l2TxNumberInBatch",
-        "type": "uint16"
-      },
-      {
-        "internalType": "bytes32[]",
-        "name": "_merkleProof",
-        "type": "bytes32[]"
-      }
-    ],
-    "name": "claimFailedDeposit",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "address",
         "name": "_originalCaller",
         "type": "address"
@@ -917,7 +618,7 @@
     ],
     "name": "finalizeDeposit",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -990,19 +691,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_owner",
-        "type": "address"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "_chainId",
         "type": "uint256"
@@ -1030,11 +718,17 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "legacyBridge",
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "l2BridgeAddress",
     "outputs": [
       {
-        "internalType": "contract IL1ERC20Bridge",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -1053,59 +747,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "pause",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "paused",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "pendingOwner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "renounceOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -1196,26 +837,6 @@
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "unpause",
-    "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/abi/IL1NativeTokenVault.json
+++ b/abi/IL1NativeTokenVault.json
@@ -1,246 +1,300 @@
 [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "bridgedTokenBeacon",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes32",
-          "name": "bridgedTokenProxyBytecodeHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "BridgedTokenBeaconUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2TokenBeacon",
-          "type": "address"
-        }
-      ],
-      "name": "TokenBeaconUpdated",
-      "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "ASSET_ROUTER",
-      "outputs": [
-        {
-          "internalType": "contract IAssetRouterBase",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "L1_NULLIFIER",
-      "outputs": [
-        {
-          "internalType": "contract IL1Nullifier",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "WETH_TOKEN",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "token",
-          "type": "address"
-        }
-      ],
-      "name": "assetId",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_chainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "_tokenAddress",
-          "type": "address"
-        }
-      ],
-      "name": "calculateAssetId",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_originChainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "_originToken",
-          "type": "address"
-        }
-      ],
-      "name": "calculateCreate2TokenAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_chainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_assetId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "chainBalance",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_token",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_originChainId",
-          "type": "uint256"
-        }
-      ],
-      "name": "getERC20Getters",
-      "outputs": [
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "originChainId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "registerEthToken",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_l1Token",
-          "type": "address"
-        }
-      ],
-      "name": "registerToken",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "tokenAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
-  ]
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "bridgedTokenBeacon",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bridgedTokenProxyBytecodeHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "BridgedTokenBeaconUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2TokenBeacon",
+        "type": "address"
+      }
+    ],
+    "name": "TokenBeaconUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ASSET_ROUTER",
+    "outputs": [
+      {
+        "internalType": "contract IAssetRouterBase",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L1_CHAIN_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L1_NULLIFIER",
+    "outputs": [
+      {
+        "internalType": "contract IL1Nullifier",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WETH_TOKEN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "assetId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_originalCaller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_assetHandlerAddressOnCounterpart",
+        "type": "address"
+      }
+    ],
+    "name": "bridgeCheckCounterpartAddress",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_originToken",
+        "type": "address"
+      }
+    ],
+    "name": "calculateCreate2TokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "chainBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_nativeToken",
+        "type": "address"
+      }
+    ],
+    "name": "ensureTokenIsRegistered",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getERC20Getters",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "originChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registerEthToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1Token",
+        "type": "address"
+      }
+    ],
+    "name": "registerToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "tokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_burnData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_expectedAssetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "tryRegisterTokenFromBurnData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abi/IL1Nullifier.json
+++ b/abi/IL1Nullifier.json
@@ -1,1 +1,484 @@
-[{"type":"constructor","inputs":[{"name":"_bridgehub","type":"address","internalType":"contract IBridgehub"},{"name":"_interopCenter","type":"address","internalType":"contract IInteropCenter"},{"name":"_eraChainId","type":"uint256","internalType":"uint256"},{"name":"_eraDiamondProxy","type":"address","internalType":"address"}],"stateMutability":"nonpayable"},{"type":"function","name":"BRIDGE_HUB","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IBridgehub"}],"stateMutability":"view"},{"type":"function","name":"__DEPRECATED_admin","inputs":[],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"__DEPRECATED_chainBalance","inputs":[{"name":"chainId","type":"uint256","internalType":"uint256"},{"name":"l1Token","type":"address","internalType":"address"}],"outputs":[{"name":"balance","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"__DEPRECATED_l2BridgeAddress","inputs":[{"name":"chainId","type":"uint256","internalType":"uint256"}],"outputs":[{"name":"l2Bridge","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"__DEPRECATED_pendingAdmin","inputs":[],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"acceptOwnership","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"bridgeRecoverFailedTransfer","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"},{"name":"_depositSender","type":"address","internalType":"address"},{"name":"_assetId","type":"bytes32","internalType":"bytes32"},{"name":"_assetData","type":"bytes","internalType":"bytes"},{"name":"_l2TxHash","type":"bytes32","internalType":"bytes32"},{"name":"_l2BatchNumber","type":"uint256","internalType":"uint256"},{"name":"_l2MessageIndex","type":"uint256","internalType":"uint256"},{"name":"_l2TxNumberInBatch","type":"uint16","internalType":"uint16"},{"name":"_merkleProof","type":"bytes32[]","internalType":"bytes32[]"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"bridgehubConfirmL2TransactionForwarded","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"},{"name":"_txDataHash","type":"bytes32","internalType":"bytes32"},{"name":"_txHash","type":"bytes32","internalType":"bytes32"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"chainBalance","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"},{"name":"_token","type":"address","internalType":"address"}],"outputs":[{"name":"","type":"uint256","internalType":"uint256"}],"stateMutability":"view"},{"type":"function","name":"claimFailedDeposit","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"},{"name":"_depositSender","type":"address","internalType":"address"},{"name":"_l1Token","type":"address","internalType":"address"},{"name":"_amount","type":"uint256","internalType":"uint256"},{"name":"_l2TxHash","type":"bytes32","internalType":"bytes32"},{"name":"_l2BatchNumber","type":"uint256","internalType":"uint256"},{"name":"_l2MessageIndex","type":"uint256","internalType":"uint256"},{"name":"_l2TxNumberInBatch","type":"uint16","internalType":"uint16"},{"name":"_merkleProof","type":"bytes32[]","internalType":"bytes32[]"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"claimFailedDepositLegacyErc20Bridge","inputs":[{"name":"_depositSender","type":"address","internalType":"address"},{"name":"_l1Token","type":"address","internalType":"address"},{"name":"_amount","type":"uint256","internalType":"uint256"},{"name":"_l2TxHash","type":"bytes32","internalType":"bytes32"},{"name":"_l2BatchNumber","type":"uint256","internalType":"uint256"},{"name":"_l2MessageIndex","type":"uint256","internalType":"uint256"},{"name":"_l2TxNumberInBatch","type":"uint16","internalType":"uint16"},{"name":"_merkleProof","type":"bytes32[]","internalType":"bytes32[]"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"depositHappened","inputs":[{"name":"chainId","type":"uint256","internalType":"uint256"},{"name":"l2DepositTxHash","type":"bytes32","internalType":"bytes32"}],"outputs":[{"name":"depositDataHash","type":"bytes32","internalType":"bytes32"}],"stateMutability":"view"},{"type":"function","name":"encodeTxDataHash","inputs":[{"name":"_encodingVersion","type":"bytes1","internalType":"bytes1"},{"name":"_originalCaller","type":"address","internalType":"address"},{"name":"_assetId","type":"bytes32","internalType":"bytes32"},{"name":"_transferData","type":"bytes","internalType":"bytes"}],"outputs":[{"name":"txDataHash","type":"bytes32","internalType":"bytes32"}],"stateMutability":"view"},{"type":"function","name":"finalizeDeposit","inputs":[{"name":"_finalizeWithdrawalParams","type":"tuple","internalType":"struct FinalizeL1DepositParams","components":[{"name":"chainId","type":"uint256","internalType":"uint256"},{"name":"l2BatchNumber","type":"uint256","internalType":"uint256"},{"name":"l2MessageIndex","type":"uint256","internalType":"uint256"},{"name":"l2Sender","type":"address","internalType":"address"},{"name":"l2TxNumberInBatch","type":"uint16","internalType":"uint16"},{"name":"message","type":"bytes","internalType":"bytes"},{"name":"merkleProof","type":"bytes32[]","internalType":"bytes32[]"}]}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"finalizeWithdrawal","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"},{"name":"_l2BatchNumber","type":"uint256","internalType":"uint256"},{"name":"_l2MessageIndex","type":"uint256","internalType":"uint256"},{"name":"_l2TxNumberInBatch","type":"uint16","internalType":"uint16"},{"name":"_message","type":"bytes","internalType":"bytes"},{"name":"_merkleProof","type":"bytes32[]","internalType":"bytes32[]"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"initialize","inputs":[{"name":"_owner","type":"address","internalType":"address"},{"name":"_eraPostDiamondUpgradeFirstBatch","type":"uint256","internalType":"uint256"},{"name":"_eraPostLegacyBridgeUpgradeFirstBatch","type":"uint256","internalType":"uint256"},{"name":"_eraLegacyBridgeLastDepositBatch","type":"uint256","internalType":"uint256"},{"name":"_eraLegacyBridgeLastDepositTxNumber","type":"uint256","internalType":"uint256"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"isWithdrawalFinalized","inputs":[{"name":"chainId","type":"uint256","internalType":"uint256"},{"name":"l2BatchNumber","type":"uint256","internalType":"uint256"},{"name":"l2ToL1MessageNumber","type":"uint256","internalType":"uint256"}],"outputs":[{"name":"isFinalized","type":"bool","internalType":"bool"}],"stateMutability":"view"},{"type":"function","name":"l1AssetRouter","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IL1AssetRouter"}],"stateMutability":"view"},{"type":"function","name":"l1NativeTokenVault","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IL1NativeTokenVault"}],"stateMutability":"view"},{"type":"function","name":"l2BridgeAddress","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"}],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"legacyBridge","inputs":[],"outputs":[{"name":"","type":"address","internalType":"contract IL1ERC20Bridge"}],"stateMutability":"view"},{"type":"function","name":"nullifyChainBalanceByNTV","inputs":[{"name":"_chainId","type":"uint256","internalType":"uint256"},{"name":"_token","type":"address","internalType":"address"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"owner","inputs":[],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"pause","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"paused","inputs":[],"outputs":[{"name":"","type":"bool","internalType":"bool"}],"stateMutability":"view"},{"type":"function","name":"pendingOwner","inputs":[],"outputs":[{"name":"","type":"address","internalType":"address"}],"stateMutability":"view"},{"type":"function","name":"renounceOwnership","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"setL1AssetRouter","inputs":[{"name":"_l1AssetRouter","type":"address","internalType":"address"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"setL1Erc20Bridge","inputs":[{"name":"_legacyBridge","type":"address","internalType":"contract IL1ERC20Bridge"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"setL1NativeTokenVault","inputs":[{"name":"_l1NativeTokenVault","type":"address","internalType":"contract IL1NativeTokenVault"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"transferOwnership","inputs":[{"name":"newOwner","type":"address","internalType":"address"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"transferTokenToNTV","inputs":[{"name":"_token","type":"address","internalType":"address"}],"outputs":[],"stateMutability":"nonpayable"},{"type":"function","name":"unpause","inputs":[],"outputs":[],"stateMutability":"nonpayable"},{"type":"event","name":"BridgehubDepositFinalized","inputs":[{"name":"chainId","type":"uint256","indexed":true,"internalType":"uint256"},{"name":"txDataHash","type":"bytes32","indexed":true,"internalType":"bytes32"},{"name":"l2DepositTxHash","type":"bytes32","indexed":true,"internalType":"bytes32"}],"anonymous":false},{"type":"event","name":"Initialized","inputs":[{"name":"version","type":"uint8","indexed":false,"internalType":"uint8"}],"anonymous":false},{"type":"event","name":"OwnershipTransferStarted","inputs":[{"name":"previousOwner","type":"address","indexed":true,"internalType":"address"},{"name":"newOwner","type":"address","indexed":true,"internalType":"address"}],"anonymous":false},{"type":"event","name":"OwnershipTransferred","inputs":[{"name":"previousOwner","type":"address","indexed":true,"internalType":"address"},{"name":"newOwner","type":"address","indexed":true,"internalType":"address"}],"anonymous":false},{"type":"event","name":"Paused","inputs":[{"name":"account","type":"address","indexed":false,"internalType":"address"}],"anonymous":false},{"type":"event","name":"Unpaused","inputs":[{"name":"account","type":"address","indexed":false,"internalType":"address"}],"anonymous":false},{"type":"error","name":"AddressAlreadySet","inputs":[{"name":"addr","type":"address","internalType":"address"}]},{"type":"error","name":"DepositDoesNotExist","inputs":[{"name":"","type":"bytes32","internalType":"bytes32"},{"name":"","type":"bytes32","internalType":"bytes32"}]},{"type":"error","name":"DepositExists","inputs":[]},{"type":"error","name":"EthTransferFailed","inputs":[]},{"type":"error","name":"IncorrectTokenAddressFromNTV","inputs":[{"name":"assetId","type":"bytes32","internalType":"bytes32"},{"name":"tokenAddress","type":"address","internalType":"address"}]},{"type":"error","name":"InvalidNTVBurnData","inputs":[]},{"type":"error","name":"InvalidProof","inputs":[]},{"type":"error","name":"InvalidSelector","inputs":[{"name":"func","type":"bytes4","internalType":"bytes4"}]},{"type":"error","name":"L2WithdrawalMessageWrongLength","inputs":[{"name":"messageLen","type":"uint256","internalType":"uint256"}]},{"type":"error","name":"LegacyBridgeNotSet","inputs":[]},{"type":"error","name":"LegacyMethodForNonL1Token","inputs":[]},{"type":"error","name":"NativeTokenVaultAlreadySet","inputs":[]},{"type":"error","name":"NotInitializedReentrancyGuard","inputs":[]},{"type":"error","name":"Reentrancy","inputs":[]},{"type":"error","name":"SharedBridgeValueNotSet","inputs":[{"name":"","type":"uint8","internalType":"enum SharedBridgeKey"}]},{"type":"error","name":"SlotOccupied","inputs":[]},{"type":"error","name":"TokenNotLegacy","inputs":[]},{"type":"error","name":"Unauthorized","inputs":[{"name":"caller","type":"address","internalType":"address"}]},{"type":"error","name":"UnsupportedEncodingVersion","inputs":[]},{"type":"error","name":"WithdrawalAlreadyFinalized","inputs":[]},{"type":"error","name":"WrongL2Sender","inputs":[{"name":"providedL2Sender","type":"address","internalType":"address"}]},{"type":"error","name":"WrongMsgLength","inputs":[{"name":"expected","type":"uint256","internalType":"uint256"},{"name":"length","type":"uint256","internalType":"uint256"}]},{"type":"error","name":"ZeroAddress","inputs":[]}]
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txDataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "l2DepositTxHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "BridgehubDepositFinalized",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BRIDGE_HUB",
+    "outputs": [
+      {
+        "internalType": "contract IBridgehub",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_depositSender",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_assetData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_l2TxHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_l2TxNumberInBatch",
+        "type": "uint16"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "bridgeRecoverFailedTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_txDataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_txHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "bridgehubConfirmL2TransactionForwarded",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "chainBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_depositSender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l1Token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_l2TxHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_l2TxNumberInBatch",
+        "type": "uint16"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claimFailedDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_depositSender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l1Token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_l2TxHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_l2TxNumberInBatch",
+        "type": "uint16"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claimFailedDepositLegacyErc20Bridge",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_l2TxHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "depositHappened",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2BatchNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2MessageIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "l2Sender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint16",
+            "name": "l2TxNumberInBatch",
+            "type": "uint16"
+          },
+          {
+            "internalType": "bytes",
+            "name": "message",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "merkleProof",
+            "type": "bytes32[]"
+          }
+        ],
+        "internalType": "struct FinalizeL1DepositParams",
+        "name": "_finalizeWithdrawalParams",
+        "type": "tuple"
+      }
+    ],
+    "name": "finalizeDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_l2TxNumberInBatch",
+        "type": "uint16"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_message",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "_merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "finalizeWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2BatchNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MessageIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "isWithdrawalFinalized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1NativeTokenVault",
+    "outputs": [
+      {
+        "internalType": "contract IL1NativeTokenVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "l2BridgeAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "legacyBridge",
+    "outputs": [
+      {
+        "internalType": "contract IL1ERC20Bridge",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "nullifyChainBalanceByNTV",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1AssetRouter",
+        "type": "address"
+      }
+    ],
+    "name": "setL1AssetRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IL1NativeTokenVault",
+        "name": "_nativeTokenVault",
+        "type": "address"
+      }
+    ],
+    "name": "setL1NativeTokenVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "transferTokenToNTV",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abi/IL2AssetRouter.json
+++ b/abi/IL2AssetRouter.json
@@ -1,371 +1,408 @@
-{
-  "_format": "hh-sol-artifact-1",
-  "contractName": "IL2AssetRouter",
-  "sourceName": "contracts/bridge/asset-router/IL2AssetRouter.sol",
-  "abi": [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "_assetAddress",
-          "type": "address"
-        }
-      ],
-      "name": "AssetHandlerRegistered",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "assetHandlerAddress",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "additionalData",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "assetDeploymentTracker",
-          "type": "address"
-        }
-      ],
-      "name": "AssetHandlerRegisteredInitial",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "BridgehubDepositBaseTokenInitiated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "txDataHash",
-          "type": "bytes32"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "from",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "bridgeMintCalldata",
-          "type": "bytes"
-        }
-      ],
-      "name": "BridgehubDepositInitiated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "sender",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes32",
-          "name": "assetDataHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "BridgehubWithdrawalInitiated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "assetData",
-          "type": "bytes"
-        }
-      ],
-      "name": "DepositFinalizedAssetRouter",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2Sender",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "assetData",
-          "type": "bytes"
-        }
-      ],
-      "name": "WithdrawalInitiatedAssetRouter",
-      "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "BRIDGE_HUB",
-      "outputs": [
-        {
-          "internalType": "contract IBridgehub",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_assetId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "assetHandlerAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_chainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_assetId",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes",
-          "name": "_transferData",
-          "type": "bytes"
-        }
-      ],
-      "name": "finalizeDeposit",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "l1AssetRouter",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_originChainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "_assetId",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "address",
-          "name": "_assetAddress",
-          "type": "address"
-        }
-      ],
-      "name": "setAssetHandlerAddress",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_assetRegistrationData",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "address",
-          "name": "_assetHandlerAddress",
-          "type": "address"
-        }
-      ],
-      "name": "setAssetHandlerAddressThisChain",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "_assetId",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes",
-          "name": "_transferData",
-          "type": "bytes"
-        }
-      ],
-      "name": "withdraw",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_l1Receiver",
-          "type": "address"
-        },
-        {
-          "internalType": "address",
-          "name": "_l2Token",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_amount",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "_sender",
-          "type": "address"
-        }
-      ],
-      "name": "withdrawLegacyBridge",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    }
-  ],
-  "bytecode": "0x",
-  "deployedBytecode": "0x",
-  "linkReferences": {},
-  "deployedLinkReferences": {}
-}
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "additionalData",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "assetDeploymentTracker",
+        "type": "address"
+      }
+    ],
+    "name": "AssetDeploymentTrackerRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_assetHandlerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "AssetHandlerRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BridgehubDepositBaseTokenInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txDataHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "bridgeMintCalldata",
+        "type": "bytes"
+      }
+    ],
+    "name": "BridgehubDepositInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "assetDataHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "BridgehubWithdrawalInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "assetData",
+        "type": "bytes"
+      }
+    ],
+    "name": "DepositFinalizedAssetRouter",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "assetData",
+        "type": "bytes"
+      }
+    ],
+    "name": "WithdrawalInitiatedAssetRouter",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BRIDGE_HUB",
+    "outputs": [
+      {
+        "internalType": "contract IBridgehub",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L1_ASSET_ROUTER",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assetHandlerAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_transferData",
+        "type": "bytes"
+      }
+    ],
+    "name": "finalizeDeposit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1Sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l2Receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l1Token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "finalizeDepositLegacyBridge",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_assetHandlerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setAssetHandlerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_assetRegistrationData",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_assetHandlerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setAssetHandlerAddressThisChain",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "setLegacyTokenAssetHandler",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_transferData",
+        "type": "bytes"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1Receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_l2Token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_sender",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawLegacyBridge",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abi/IL2NativeTokenVault.json
+++ b/abi/IL2NativeTokenVault.json
@@ -1,298 +1,890 @@
-{
-  "_format": "hh-sol-artifact-1",
-  "contractName": "IL2NativeTokenVault",
-  "sourceName": "contracts/bridge/ntv/IL2NativeTokenVault.sol",
-  "abi": [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "bridgedTokenBeacon",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes32",
-          "name": "bridgedTokenProxyBytecodeHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "BridgedTokenBeaconUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l1Sender",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2Receiver",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2Token",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "FinalizeDeposit",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2TokenBeacon",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "bytes32",
-          "name": "l2TokenProxyBytecodeHash",
-          "type": "bytes32"
-        }
-      ],
-      "name": "L2TokenBeaconUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2Sender",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l1Receiver",
-          "type": "address"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2Token",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        }
-      ],
-      "name": "WithdrawalInitiated",
-      "type": "event"
-    },
-    {
-      "inputs": [],
-      "name": "ASSET_ROUTER",
-      "outputs": [
-        {
-          "internalType": "contract IAssetRouterBase",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "WETH_TOKEN",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "token",
-          "type": "address"
-        }
-      ],
-      "name": "assetId",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_chainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "_tokenAddress",
-          "type": "address"
-        }
-      ],
-      "name": "calculateAssetId",
-      "outputs": [
-        {
-          "internalType": "bytes32",
-          "name": "",
-          "type": "bytes32"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_originChainId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "address",
-          "name": "_originToken",
-          "type": "address"
-        }
-      ],
-      "name": "calculateCreate2TokenAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_token",
-          "type": "address"
-        },
-        {
-          "internalType": "uint256",
-          "name": "_originChainId",
-          "type": "uint256"
-        }
-      ],
-      "name": "getERC20Getters",
-      "outputs": [
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_l1Token",
-          "type": "address"
-        }
-      ],
-      "name": "l2TokenAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "originChainId",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "_l1Token",
-          "type": "address"
-        }
-      ],
-      "name": "registerToken",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes32",
-          "name": "assetId",
-          "type": "bytes32"
-        }
-      ],
-      "name": "tokenAddress",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
-  ],
-  "bytecode": "0x",
-  "deployedBytecode": "0x",
-  "linkReferences": {},
-  "deployedLinkReferences": {}
-}
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_l1ChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_aliasedOwner",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_l2TokenProxyBytecodeHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_legacySharedBridge",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_bridgedTokenBeacon",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_contractsDeployedAlready",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_wethToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_baseTokenAssetId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "expected",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "supplied",
+        "type": "address"
+      }
+    ],
+    "name": "AddressMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AmountMustBeGreaterThanZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AssetIdAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "expected",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "supplied",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AssetIdMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AssetIdNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "BurningNativeWETHNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DeployFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DeployingBridgedTokenForNativeToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyBytes32",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyDeposit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EmptyToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidNTVBurnData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoLegacySharedBridge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NonEmptyMsgValue",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokenIsLegacy",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokenNotLegacy",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokensWithFeesNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "U32CastOverflow",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnsupportedEncodingVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "expected",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "actual",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValueMismatch",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BridgeBurn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "BridgeMint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "bridgedTokenBeacon",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "bridgedTokenProxyBytecodeHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "BridgedTokenBeaconUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FinalizeDeposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2TokenBeacon",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "l2TokenProxyBytecodeHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "L2TokenBeaconUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l1Receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "l2Token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalInitiated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ASSET_ROUTER",
+    "outputs": [
+      {
+        "internalType": "contract IAssetRouterBase",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "BASE_TOKEN_ASSET_ID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L1_CHAIN_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "L2_LEGACY_SHARED_BRIDGE",
+    "outputs": [
+      {
+        "internalType": "contract IL2SharedBridgeLegacy",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WETH_TOKEN",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "assetId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_l2MsgValue",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_originalCaller",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "bridgeBurn",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "_bridgeMintData",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_assetId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "bridgeMint",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bridgedTokenBeacon",
+    "outputs": [
+      {
+        "internalType": "contract IBeacon",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_tokenOriginChainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_nonNativeToken",
+        "type": "address"
+      }
+    ],
+    "name": "calculateCreate2TokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_nativeToken",
+        "type": "address"
+      }
+    ],
+    "name": "ensureTokenIsRegistered",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "tokenAssetId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_originChainId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getERC20Getters",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1Token",
+        "type": "address"
+      }
+    ],
+    "name": "l2TokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "expectedToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "originChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "originChainId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_nativeToken",
+        "type": "address"
+      }
+    ],
+    "name": "registerToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l2TokenAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setLegacyTokenAssetId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "tokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "tokenAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_erc20Data",
+        "type": "bytes"
+      }
+    ],
+    "name": "tokenDataOriginChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenOriginChainId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_burnData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_expectedAssetId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "tryRegisterTokenFromBurnData",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/typechain/IBridgehub.ts
+++ b/src/typechain/IBridgehub.ts
@@ -131,65 +131,184 @@ export type L2TransactionRequestTwoBridgesOuterStructOutput = [
 export interface IBridgehubInterface extends Interface {
   getFunction(
     nameOrSignature:
+      | "L1_CHAIN_ID"
       | "acceptAdmin"
-      | "addStateTransitionManager"
-      | "addToken"
+      | "addChainTypeManager"
+      | "addTokenAssetId"
+      | "admin"
+      | "assetIdIsRegistered"
+      | "assetRouter"
       | "baseToken"
+      | "baseTokenAssetId"
+      | "bridgeBurn"
+      | "bridgeMint"
+      | "bridgeRecoverFailedTransfer"
+      | "chainTypeManager"
+      | "chainTypeManagerIsRegistered"
       | "createNewChain"
+      | "ctmAssetIdFromAddress"
+      | "ctmAssetIdFromChainId"
+      | "ctmAssetIdToAddress"
+      | "forwardTransactionOnGateway"
+      | "getAllZKChainChainIDs"
+      | "getAllZKChains"
       | "getHyperchain"
+      | "getZKChain"
+      | "l1CtmDeployer"
       | "l2TransactionBaseCost"
+      | "messageRoot"
+      | "migrationPaused"
+      | "pauseMigration"
       | "proveL1ToL2TransactionStatus"
       | "proveL2LogInclusion"
       | "proveL2MessageInclusion"
-      | "removeStateTransitionManager"
+      | "registerAlreadyDeployedZKChain"
+      | "registerLegacyChain"
+      | "registerSettlementLayer"
+      | "removeChainTypeManager"
       | "requestL2TransactionDirect"
       | "requestL2TransactionTwoBridges"
+      | "setAddresses"
+      | "setCTMAssetAddress"
       | "setPendingAdmin"
-      | "setSharedBridge"
+      | "settlementLayer"
       | "sharedBridge"
-      | "stateTransitionManager"
-      | "stateTransitionManagerIsRegistered"
-      | "tokenIsRegistered"
+      | "unpauseMigration"
+      | "whitelistedSettlementLayers"
   ): FunctionFragment;
 
   getEvent(
-    nameOrSignatureOrTopic: "NewAdmin" | "NewChain" | "NewPendingAdmin"
+    nameOrSignatureOrTopic:
+      | "AssetRegistered"
+      | "BaseTokenAssetIdRegistered"
+      | "BridgeBurn"
+      | "BridgeMint"
+      | "ChainTypeManagerAdded"
+      | "ChainTypeManagerRemoved"
+      | "MigrationFinalized"
+      | "MigrationStarted"
+      | "NewAdmin"
+      | "NewChain"
+      | "NewPendingAdmin"
+      | "SettlementLayerRegistered"
   ): EventFragment;
 
+  encodeFunctionData(
+    functionFragment: "L1_CHAIN_ID",
+    values?: undefined
+  ): string;
   encodeFunctionData(
     functionFragment: "acceptAdmin",
     values?: undefined
   ): string;
   encodeFunctionData(
-    functionFragment: "addStateTransitionManager",
+    functionFragment: "addChainTypeManager",
     values: [AddressLike]
   ): string;
   encodeFunctionData(
-    functionFragment: "addToken",
-    values: [AddressLike]
+    functionFragment: "addTokenAssetId",
+    values: [BytesLike]
+  ): string;
+  encodeFunctionData(functionFragment: "admin", values?: undefined): string;
+  encodeFunctionData(
+    functionFragment: "assetIdIsRegistered",
+    values: [BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "assetRouter",
+    values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "baseToken",
     values: [BigNumberish]
   ): string;
   encodeFunctionData(
+    functionFragment: "baseTokenAssetId",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "bridgeBurn",
+    values: [BigNumberish, BigNumberish, BytesLike, AddressLike, BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "bridgeMint",
+    values: [BigNumberish, BytesLike, BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "bridgeRecoverFailedTransfer",
+    values: [BigNumberish, BytesLike, AddressLike, BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "chainTypeManager",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "chainTypeManagerIsRegistered",
+    values: [AddressLike]
+  ): string;
+  encodeFunctionData(
     functionFragment: "createNewChain",
     values: [
       BigNumberish,
       AddressLike,
-      AddressLike,
+      BytesLike,
       BigNumberish,
       AddressLike,
-      BytesLike
+      BytesLike,
+      BytesLike[]
     ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "ctmAssetIdFromAddress",
+    values: [AddressLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "ctmAssetIdFromChainId",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "ctmAssetIdToAddress",
+    values: [BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "forwardTransactionOnGateway",
+    values: [BigNumberish, BytesLike, BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "getAllZKChainChainIDs",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "getAllZKChains",
+    values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "getHyperchain",
     values: [BigNumberish]
   ): string;
   encodeFunctionData(
+    functionFragment: "getZKChain",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "l1CtmDeployer",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
     functionFragment: "l2TransactionBaseCost",
     values: [BigNumberish, BigNumberish, BigNumberish, BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "messageRoot",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "migrationPaused",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "pauseMigration",
+    values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "proveL1ToL2TransactionStatus",
@@ -218,7 +337,19 @@ export interface IBridgehubInterface extends Interface {
     ]
   ): string;
   encodeFunctionData(
-    functionFragment: "removeStateTransitionManager",
+    functionFragment: "registerAlreadyDeployedZKChain",
+    values: [BigNumberish, AddressLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "registerLegacyChain",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "registerSettlementLayer",
+    values: [BigNumberish, boolean]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "removeChainTypeManager",
     values: [AddressLike]
   ): string;
   encodeFunctionData(
@@ -230,50 +361,129 @@ export interface IBridgehubInterface extends Interface {
     values: [L2TransactionRequestTwoBridgesOuterStruct]
   ): string;
   encodeFunctionData(
+    functionFragment: "setAddresses",
+    values: [AddressLike, AddressLike, AddressLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setCTMAssetAddress",
+    values: [BytesLike, AddressLike]
+  ): string;
+  encodeFunctionData(
     functionFragment: "setPendingAdmin",
     values: [AddressLike]
   ): string;
   encodeFunctionData(
-    functionFragment: "setSharedBridge",
-    values: [AddressLike]
+    functionFragment: "settlementLayer",
+    values: [BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "sharedBridge",
     values?: undefined
   ): string;
   encodeFunctionData(
-    functionFragment: "stateTransitionManager",
+    functionFragment: "unpauseMigration",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "whitelistedSettlementLayers",
     values: [BigNumberish]
   ): string;
-  encodeFunctionData(
-    functionFragment: "stateTransitionManagerIsRegistered",
-    values: [AddressLike]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "tokenIsRegistered",
-    values: [AddressLike]
-  ): string;
 
+  decodeFunctionResult(
+    functionFragment: "L1_CHAIN_ID",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "acceptAdmin",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "addStateTransitionManager",
+    functionFragment: "addChainTypeManager",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "addToken", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "addTokenAssetId",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(functionFragment: "admin", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "assetIdIsRegistered",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "assetRouter",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(functionFragment: "baseToken", data: BytesLike): Result;
   decodeFunctionResult(
+    functionFragment: "baseTokenAssetId",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(functionFragment: "bridgeBurn", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "bridgeMint", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "bridgeRecoverFailedTransfer",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "chainTypeManager",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "chainTypeManagerIsRegistered",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "createNewChain",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "ctmAssetIdFromAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "ctmAssetIdFromChainId",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "ctmAssetIdToAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "forwardTransactionOnGateway",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "getAllZKChainChainIDs",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "getAllZKChains",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "getHyperchain",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "getZKChain", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "l1CtmDeployer",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "l2TransactionBaseCost",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "messageRoot",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "migrationPaused",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "pauseMigration",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -289,7 +499,19 @@ export interface IBridgehubInterface extends Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "removeStateTransitionManager",
+    functionFragment: "registerAlreadyDeployedZKChain",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "registerLegacyChain",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "registerSettlementLayer",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "removeChainTypeManager",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -301,11 +523,19 @@ export interface IBridgehubInterface extends Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "setAddresses",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setCTMAssetAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "setPendingAdmin",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "setSharedBridge",
+    functionFragment: "settlementLayer",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -313,17 +543,167 @@ export interface IBridgehubInterface extends Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "stateTransitionManager",
+    functionFragment: "unpauseMigration",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "stateTransitionManagerIsRegistered",
+    functionFragment: "whitelistedSettlementLayers",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(
-    functionFragment: "tokenIsRegistered",
-    data: BytesLike
-  ): Result;
+}
+
+export namespace AssetRegisteredEvent {
+  export type InputTuple = [
+    assetInfo: BytesLike,
+    _assetAddress: AddressLike,
+    additionalData: BytesLike,
+    sender: AddressLike
+  ];
+  export type OutputTuple = [
+    assetInfo: string,
+    _assetAddress: string,
+    additionalData: string,
+    sender: string
+  ];
+  export interface OutputObject {
+    assetInfo: string;
+    _assetAddress: string;
+    additionalData: string;
+    sender: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace BaseTokenAssetIdRegisteredEvent {
+  export type InputTuple = [assetId: BytesLike];
+  export type OutputTuple = [assetId: string];
+  export interface OutputObject {
+    assetId: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace BridgeBurnEvent {
+  export type InputTuple = [
+    chainId: BigNumberish,
+    assetId: BytesLike,
+    sender: AddressLike,
+    receiver: AddressLike,
+    amount: BigNumberish
+  ];
+  export type OutputTuple = [
+    chainId: bigint,
+    assetId: string,
+    sender: string,
+    receiver: string,
+    amount: bigint
+  ];
+  export interface OutputObject {
+    chainId: bigint;
+    assetId: string;
+    sender: string;
+    receiver: string;
+    amount: bigint;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace BridgeMintEvent {
+  export type InputTuple = [
+    chainId: BigNumberish,
+    assetId: BytesLike,
+    receiver: AddressLike,
+    amount: BigNumberish
+  ];
+  export type OutputTuple = [
+    chainId: bigint,
+    assetId: string,
+    receiver: string,
+    amount: bigint
+  ];
+  export interface OutputObject {
+    chainId: bigint;
+    assetId: string;
+    receiver: string;
+    amount: bigint;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace ChainTypeManagerAddedEvent {
+  export type InputTuple = [chainTypeManager: AddressLike];
+  export type OutputTuple = [chainTypeManager: string];
+  export interface OutputObject {
+    chainTypeManager: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace ChainTypeManagerRemovedEvent {
+  export type InputTuple = [chainTypeManager: AddressLike];
+  export type OutputTuple = [chainTypeManager: string];
+  export interface OutputObject {
+    chainTypeManager: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace MigrationFinalizedEvent {
+  export type InputTuple = [
+    chainId: BigNumberish,
+    assetId: BytesLike,
+    zkChain: AddressLike
+  ];
+  export type OutputTuple = [chainId: bigint, assetId: string, zkChain: string];
+  export interface OutputObject {
+    chainId: bigint;
+    assetId: string;
+    zkChain: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace MigrationStartedEvent {
+  export type InputTuple = [
+    chainId: BigNumberish,
+    assetId: BytesLike,
+    settlementLayerChainId: BigNumberish
+  ];
+  export type OutputTuple = [
+    chainId: bigint,
+    assetId: string,
+    settlementLayerChainId: bigint
+  ];
+  export interface OutputObject {
+    chainId: bigint;
+    assetId: string;
+    settlementLayerChainId: bigint;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
 }
 
 export namespace NewAdminEvent {
@@ -342,17 +722,17 @@ export namespace NewAdminEvent {
 export namespace NewChainEvent {
   export type InputTuple = [
     chainId: BigNumberish,
-    stateTransitionManager: AddressLike,
+    chainTypeManager: AddressLike,
     chainGovernance: AddressLike
   ];
   export type OutputTuple = [
     chainId: bigint,
-    stateTransitionManager: string,
+    chainTypeManager: string,
     chainGovernance: string
   ];
   export interface OutputObject {
     chainId: bigint;
-    stateTransitionManager: string;
+    chainTypeManager: string;
     chainGovernance: string;
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
@@ -370,6 +750,19 @@ export namespace NewPendingAdminEvent {
   export interface OutputObject {
     oldPendingAdmin: string;
     newPendingAdmin: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace SettlementLayerRegisteredEvent {
+  export type InputTuple = [chainId: BigNumberish, isWhitelisted: boolean];
+  export type OutputTuple = [chainId: bigint, isWhitelisted: boolean];
+  export interface OutputObject {
+    chainId: bigint;
+    isWhitelisted: boolean;
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
@@ -420,36 +813,136 @@ export interface IBridgehub extends BaseContract {
     event?: TCEvent
   ): Promise<this>;
 
+  L1_CHAIN_ID: TypedContractMethod<[], [bigint], "view">;
+
   acceptAdmin: TypedContractMethod<[], [void], "nonpayable">;
 
-  addStateTransitionManager: TypedContractMethod<
-    [_stateTransitionManager: AddressLike],
+  addChainTypeManager: TypedContractMethod<
+    [_chainTypeManager: AddressLike],
     [void],
     "nonpayable"
   >;
 
-  addToken: TypedContractMethod<[_token: AddressLike], [void], "nonpayable">;
+  addTokenAssetId: TypedContractMethod<
+    [_baseTokenAssetId: BytesLike],
+    [void],
+    "nonpayable"
+  >;
+
+  admin: TypedContractMethod<[], [string], "view">;
+
+  assetIdIsRegistered: TypedContractMethod<
+    [_baseTokenAssetId: BytesLike],
+    [boolean],
+    "view"
+  >;
+
+  assetRouter: TypedContractMethod<[], [string], "view">;
 
   baseToken: TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+
+  baseTokenAssetId: TypedContractMethod<
+    [_chainId: BigNumberish],
+    [string],
+    "view"
+  >;
+
+  bridgeBurn: TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _msgValue: BigNumberish,
+      _assetId: BytesLike,
+      _originalCaller: AddressLike,
+      _data: BytesLike
+    ],
+    [string],
+    "payable"
+  >;
+
+  bridgeMint: TypedContractMethod<
+    [_chainId: BigNumberish, _assetId: BytesLike, _data: BytesLike],
+    [void],
+    "payable"
+  >;
+
+  bridgeRecoverFailedTransfer: TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _assetId: BytesLike,
+      _depositSender: AddressLike,
+      _data: BytesLike
+    ],
+    [void],
+    "payable"
+  >;
+
+  chainTypeManager: TypedContractMethod<
+    [_chainId: BigNumberish],
+    [string],
+    "view"
+  >;
+
+  chainTypeManagerIsRegistered: TypedContractMethod<
+    [_chainTypeManager: AddressLike],
+    [boolean],
+    "view"
+  >;
 
   createNewChain: TypedContractMethod<
     [
       _chainId: BigNumberish,
-      _stateTransitionManager: AddressLike,
-      _baseToken: AddressLike,
+      _chainTypeManager: AddressLike,
+      _baseTokenAssetId: BytesLike,
       _salt: BigNumberish,
       _admin: AddressLike,
-      _initData: BytesLike
+      _initData: BytesLike,
+      _factoryDeps: BytesLike[]
     ],
     [bigint],
     "nonpayable"
   >;
+
+  ctmAssetIdFromAddress: TypedContractMethod<
+    [_ctmAddress: AddressLike],
+    [string],
+    "view"
+  >;
+
+  ctmAssetIdFromChainId: TypedContractMethod<
+    [_chainId: BigNumberish],
+    [string],
+    "view"
+  >;
+
+  ctmAssetIdToAddress: TypedContractMethod<
+    [_assetInfo: BytesLike],
+    [string],
+    "view"
+  >;
+
+  forwardTransactionOnGateway: TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _canonicalTxHash: BytesLike,
+      _expirationTimestamp: BigNumberish
+    ],
+    [void],
+    "nonpayable"
+  >;
+
+  getAllZKChainChainIDs: TypedContractMethod<[], [bigint[]], "view">;
+
+  getAllZKChains: TypedContractMethod<[], [string[]], "view">;
 
   getHyperchain: TypedContractMethod<
     [_chainId: BigNumberish],
     [string],
     "view"
   >;
+
+  getZKChain: TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+
+  l1CtmDeployer: TypedContractMethod<[], [string], "view">;
 
   l2TransactionBaseCost: TypedContractMethod<
     [
@@ -461,6 +954,12 @@ export interface IBridgehub extends BaseContract {
     [bigint],
     "view"
   >;
+
+  messageRoot: TypedContractMethod<[], [string], "view">;
+
+  migrationPaused: TypedContractMethod<[], [boolean], "view">;
+
+  pauseMigration: TypedContractMethod<[], [void], "nonpayable">;
 
   proveL1ToL2TransactionStatus: TypedContractMethod<
     [
@@ -500,8 +999,26 @@ export interface IBridgehub extends BaseContract {
     "view"
   >;
 
-  removeStateTransitionManager: TypedContractMethod<
-    [_stateTransitionManager: AddressLike],
+  registerAlreadyDeployedZKChain: TypedContractMethod<
+    [_chainId: BigNumberish, _hyperchain: AddressLike],
+    [void],
+    "nonpayable"
+  >;
+
+  registerLegacyChain: TypedContractMethod<
+    [_chainId: BigNumberish],
+    [void],
+    "nonpayable"
+  >;
+
+  registerSettlementLayer: TypedContractMethod<
+    [_newSettlementLayerChainId: BigNumberish, _isWhitelisted: boolean],
+    [void],
+    "nonpayable"
+  >;
+
+  removeChainTypeManager: TypedContractMethod<
+    [_chainTypeManager: AddressLike],
     [void],
     "nonpayable"
   >;
@@ -518,34 +1035,40 @@ export interface IBridgehub extends BaseContract {
     "payable"
   >;
 
+  setAddresses: TypedContractMethod<
+    [
+      _sharedBridge: AddressLike,
+      _l1CtmDeployer: AddressLike,
+      _messageRoot: AddressLike
+    ],
+    [void],
+    "nonpayable"
+  >;
+
+  setCTMAssetAddress: TypedContractMethod<
+    [_additionalData: BytesLike, _assetAddress: AddressLike],
+    [void],
+    "nonpayable"
+  >;
+
   setPendingAdmin: TypedContractMethod<
     [_newPendingAdmin: AddressLike],
     [void],
     "nonpayable"
   >;
 
-  setSharedBridge: TypedContractMethod<
-    [_sharedBridge: AddressLike],
-    [void],
-    "nonpayable"
+  settlementLayer: TypedContractMethod<
+    [_chainId: BigNumberish],
+    [bigint],
+    "view"
   >;
 
   sharedBridge: TypedContractMethod<[], [string], "view">;
 
-  stateTransitionManager: TypedContractMethod<
+  unpauseMigration: TypedContractMethod<[], [void], "nonpayable">;
+
+  whitelistedSettlementLayers: TypedContractMethod<
     [_chainId: BigNumberish],
-    [string],
-    "view"
-  >;
-
-  stateTransitionManagerIsRegistered: TypedContractMethod<
-    [_stateTransitionManager: AddressLike],
-    [boolean],
-    "view"
-  >;
-
-  tokenIsRegistered: TypedContractMethod<
-    [_baseToken: AddressLike],
     [boolean],
     "view"
   >;
@@ -555,38 +1078,124 @@ export interface IBridgehub extends BaseContract {
   ): T;
 
   getFunction(
+    nameOrSignature: "L1_CHAIN_ID"
+  ): TypedContractMethod<[], [bigint], "view">;
+  getFunction(
     nameOrSignature: "acceptAdmin"
   ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
-    nameOrSignature: "addStateTransitionManager"
+    nameOrSignature: "addChainTypeManager"
   ): TypedContractMethod<
-    [_stateTransitionManager: AddressLike],
+    [_chainTypeManager: AddressLike],
     [void],
     "nonpayable"
   >;
   getFunction(
-    nameOrSignature: "addToken"
-  ): TypedContractMethod<[_token: AddressLike], [void], "nonpayable">;
+    nameOrSignature: "addTokenAssetId"
+  ): TypedContractMethod<[_baseTokenAssetId: BytesLike], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "admin"
+  ): TypedContractMethod<[], [string], "view">;
+  getFunction(
+    nameOrSignature: "assetIdIsRegistered"
+  ): TypedContractMethod<[_baseTokenAssetId: BytesLike], [boolean], "view">;
+  getFunction(
+    nameOrSignature: "assetRouter"
+  ): TypedContractMethod<[], [string], "view">;
   getFunction(
     nameOrSignature: "baseToken"
   ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+  getFunction(
+    nameOrSignature: "baseTokenAssetId"
+  ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+  getFunction(
+    nameOrSignature: "bridgeBurn"
+  ): TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _msgValue: BigNumberish,
+      _assetId: BytesLike,
+      _originalCaller: AddressLike,
+      _data: BytesLike
+    ],
+    [string],
+    "payable"
+  >;
+  getFunction(
+    nameOrSignature: "bridgeMint"
+  ): TypedContractMethod<
+    [_chainId: BigNumberish, _assetId: BytesLike, _data: BytesLike],
+    [void],
+    "payable"
+  >;
+  getFunction(
+    nameOrSignature: "bridgeRecoverFailedTransfer"
+  ): TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _assetId: BytesLike,
+      _depositSender: AddressLike,
+      _data: BytesLike
+    ],
+    [void],
+    "payable"
+  >;
+  getFunction(
+    nameOrSignature: "chainTypeManager"
+  ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+  getFunction(
+    nameOrSignature: "chainTypeManagerIsRegistered"
+  ): TypedContractMethod<[_chainTypeManager: AddressLike], [boolean], "view">;
   getFunction(
     nameOrSignature: "createNewChain"
   ): TypedContractMethod<
     [
       _chainId: BigNumberish,
-      _stateTransitionManager: AddressLike,
-      _baseToken: AddressLike,
+      _chainTypeManager: AddressLike,
+      _baseTokenAssetId: BytesLike,
       _salt: BigNumberish,
       _admin: AddressLike,
-      _initData: BytesLike
+      _initData: BytesLike,
+      _factoryDeps: BytesLike[]
     ],
     [bigint],
     "nonpayable"
   >;
   getFunction(
+    nameOrSignature: "ctmAssetIdFromAddress"
+  ): TypedContractMethod<[_ctmAddress: AddressLike], [string], "view">;
+  getFunction(
+    nameOrSignature: "ctmAssetIdFromChainId"
+  ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+  getFunction(
+    nameOrSignature: "ctmAssetIdToAddress"
+  ): TypedContractMethod<[_assetInfo: BytesLike], [string], "view">;
+  getFunction(
+    nameOrSignature: "forwardTransactionOnGateway"
+  ): TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _canonicalTxHash: BytesLike,
+      _expirationTimestamp: BigNumberish
+    ],
+    [void],
+    "nonpayable"
+  >;
+  getFunction(
+    nameOrSignature: "getAllZKChainChainIDs"
+  ): TypedContractMethod<[], [bigint[]], "view">;
+  getFunction(
+    nameOrSignature: "getAllZKChains"
+  ): TypedContractMethod<[], [string[]], "view">;
+  getFunction(
     nameOrSignature: "getHyperchain"
   ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+  getFunction(
+    nameOrSignature: "getZKChain"
+  ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+  getFunction(
+    nameOrSignature: "l1CtmDeployer"
+  ): TypedContractMethod<[], [string], "view">;
   getFunction(
     nameOrSignature: "l2TransactionBaseCost"
   ): TypedContractMethod<
@@ -599,6 +1208,15 @@ export interface IBridgehub extends BaseContract {
     [bigint],
     "view"
   >;
+  getFunction(
+    nameOrSignature: "messageRoot"
+  ): TypedContractMethod<[], [string], "view">;
+  getFunction(
+    nameOrSignature: "migrationPaused"
+  ): TypedContractMethod<[], [boolean], "view">;
+  getFunction(
+    nameOrSignature: "pauseMigration"
+  ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
     nameOrSignature: "proveL1ToL2TransactionStatus"
   ): TypedContractMethod<
@@ -641,9 +1259,26 @@ export interface IBridgehub extends BaseContract {
     "view"
   >;
   getFunction(
-    nameOrSignature: "removeStateTransitionManager"
+    nameOrSignature: "registerAlreadyDeployedZKChain"
   ): TypedContractMethod<
-    [_stateTransitionManager: AddressLike],
+    [_chainId: BigNumberish, _hyperchain: AddressLike],
+    [void],
+    "nonpayable"
+  >;
+  getFunction(
+    nameOrSignature: "registerLegacyChain"
+  ): TypedContractMethod<[_chainId: BigNumberish], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "registerSettlementLayer"
+  ): TypedContractMethod<
+    [_newSettlementLayerChainId: BigNumberish, _isWhitelisted: boolean],
+    [void],
+    "nonpayable"
+  >;
+  getFunction(
+    nameOrSignature: "removeChainTypeManager"
+  ): TypedContractMethod<
+    [_chainTypeManager: AddressLike],
     [void],
     "nonpayable"
   >;
@@ -662,28 +1297,95 @@ export interface IBridgehub extends BaseContract {
     "payable"
   >;
   getFunction(
+    nameOrSignature: "setAddresses"
+  ): TypedContractMethod<
+    [
+      _sharedBridge: AddressLike,
+      _l1CtmDeployer: AddressLike,
+      _messageRoot: AddressLike
+    ],
+    [void],
+    "nonpayable"
+  >;
+  getFunction(
+    nameOrSignature: "setCTMAssetAddress"
+  ): TypedContractMethod<
+    [_additionalData: BytesLike, _assetAddress: AddressLike],
+    [void],
+    "nonpayable"
+  >;
+  getFunction(
     nameOrSignature: "setPendingAdmin"
   ): TypedContractMethod<[_newPendingAdmin: AddressLike], [void], "nonpayable">;
   getFunction(
-    nameOrSignature: "setSharedBridge"
-  ): TypedContractMethod<[_sharedBridge: AddressLike], [void], "nonpayable">;
+    nameOrSignature: "settlementLayer"
+  ): TypedContractMethod<[_chainId: BigNumberish], [bigint], "view">;
   getFunction(
     nameOrSignature: "sharedBridge"
   ): TypedContractMethod<[], [string], "view">;
   getFunction(
-    nameOrSignature: "stateTransitionManager"
-  ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
+    nameOrSignature: "unpauseMigration"
+  ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
-    nameOrSignature: "stateTransitionManagerIsRegistered"
-  ): TypedContractMethod<
-    [_stateTransitionManager: AddressLike],
-    [boolean],
-    "view"
-  >;
-  getFunction(
-    nameOrSignature: "tokenIsRegistered"
-  ): TypedContractMethod<[_baseToken: AddressLike], [boolean], "view">;
+    nameOrSignature: "whitelistedSettlementLayers"
+  ): TypedContractMethod<[_chainId: BigNumberish], [boolean], "view">;
 
+  getEvent(
+    key: "AssetRegistered"
+  ): TypedContractEvent<
+    AssetRegisteredEvent.InputTuple,
+    AssetRegisteredEvent.OutputTuple,
+    AssetRegisteredEvent.OutputObject
+  >;
+  getEvent(
+    key: "BaseTokenAssetIdRegistered"
+  ): TypedContractEvent<
+    BaseTokenAssetIdRegisteredEvent.InputTuple,
+    BaseTokenAssetIdRegisteredEvent.OutputTuple,
+    BaseTokenAssetIdRegisteredEvent.OutputObject
+  >;
+  getEvent(
+    key: "BridgeBurn"
+  ): TypedContractEvent<
+    BridgeBurnEvent.InputTuple,
+    BridgeBurnEvent.OutputTuple,
+    BridgeBurnEvent.OutputObject
+  >;
+  getEvent(
+    key: "BridgeMint"
+  ): TypedContractEvent<
+    BridgeMintEvent.InputTuple,
+    BridgeMintEvent.OutputTuple,
+    BridgeMintEvent.OutputObject
+  >;
+  getEvent(
+    key: "ChainTypeManagerAdded"
+  ): TypedContractEvent<
+    ChainTypeManagerAddedEvent.InputTuple,
+    ChainTypeManagerAddedEvent.OutputTuple,
+    ChainTypeManagerAddedEvent.OutputObject
+  >;
+  getEvent(
+    key: "ChainTypeManagerRemoved"
+  ): TypedContractEvent<
+    ChainTypeManagerRemovedEvent.InputTuple,
+    ChainTypeManagerRemovedEvent.OutputTuple,
+    ChainTypeManagerRemovedEvent.OutputObject
+  >;
+  getEvent(
+    key: "MigrationFinalized"
+  ): TypedContractEvent<
+    MigrationFinalizedEvent.InputTuple,
+    MigrationFinalizedEvent.OutputTuple,
+    MigrationFinalizedEvent.OutputObject
+  >;
+  getEvent(
+    key: "MigrationStarted"
+  ): TypedContractEvent<
+    MigrationStartedEvent.InputTuple,
+    MigrationStartedEvent.OutputTuple,
+    MigrationStartedEvent.OutputObject
+  >;
   getEvent(
     key: "NewAdmin"
   ): TypedContractEvent<
@@ -705,8 +1407,103 @@ export interface IBridgehub extends BaseContract {
     NewPendingAdminEvent.OutputTuple,
     NewPendingAdminEvent.OutputObject
   >;
+  getEvent(
+    key: "SettlementLayerRegistered"
+  ): TypedContractEvent<
+    SettlementLayerRegisteredEvent.InputTuple,
+    SettlementLayerRegisteredEvent.OutputTuple,
+    SettlementLayerRegisteredEvent.OutputObject
+  >;
 
   filters: {
+    "AssetRegistered(bytes32,address,bytes32,address)": TypedContractEvent<
+      AssetRegisteredEvent.InputTuple,
+      AssetRegisteredEvent.OutputTuple,
+      AssetRegisteredEvent.OutputObject
+    >;
+    AssetRegistered: TypedContractEvent<
+      AssetRegisteredEvent.InputTuple,
+      AssetRegisteredEvent.OutputTuple,
+      AssetRegisteredEvent.OutputObject
+    >;
+
+    "BaseTokenAssetIdRegistered(bytes32)": TypedContractEvent<
+      BaseTokenAssetIdRegisteredEvent.InputTuple,
+      BaseTokenAssetIdRegisteredEvent.OutputTuple,
+      BaseTokenAssetIdRegisteredEvent.OutputObject
+    >;
+    BaseTokenAssetIdRegistered: TypedContractEvent<
+      BaseTokenAssetIdRegisteredEvent.InputTuple,
+      BaseTokenAssetIdRegisteredEvent.OutputTuple,
+      BaseTokenAssetIdRegisteredEvent.OutputObject
+    >;
+
+    "BridgeBurn(uint256,bytes32,address,address,uint256)": TypedContractEvent<
+      BridgeBurnEvent.InputTuple,
+      BridgeBurnEvent.OutputTuple,
+      BridgeBurnEvent.OutputObject
+    >;
+    BridgeBurn: TypedContractEvent<
+      BridgeBurnEvent.InputTuple,
+      BridgeBurnEvent.OutputTuple,
+      BridgeBurnEvent.OutputObject
+    >;
+
+    "BridgeMint(uint256,bytes32,address,uint256)": TypedContractEvent<
+      BridgeMintEvent.InputTuple,
+      BridgeMintEvent.OutputTuple,
+      BridgeMintEvent.OutputObject
+    >;
+    BridgeMint: TypedContractEvent<
+      BridgeMintEvent.InputTuple,
+      BridgeMintEvent.OutputTuple,
+      BridgeMintEvent.OutputObject
+    >;
+
+    "ChainTypeManagerAdded(address)": TypedContractEvent<
+      ChainTypeManagerAddedEvent.InputTuple,
+      ChainTypeManagerAddedEvent.OutputTuple,
+      ChainTypeManagerAddedEvent.OutputObject
+    >;
+    ChainTypeManagerAdded: TypedContractEvent<
+      ChainTypeManagerAddedEvent.InputTuple,
+      ChainTypeManagerAddedEvent.OutputTuple,
+      ChainTypeManagerAddedEvent.OutputObject
+    >;
+
+    "ChainTypeManagerRemoved(address)": TypedContractEvent<
+      ChainTypeManagerRemovedEvent.InputTuple,
+      ChainTypeManagerRemovedEvent.OutputTuple,
+      ChainTypeManagerRemovedEvent.OutputObject
+    >;
+    ChainTypeManagerRemoved: TypedContractEvent<
+      ChainTypeManagerRemovedEvent.InputTuple,
+      ChainTypeManagerRemovedEvent.OutputTuple,
+      ChainTypeManagerRemovedEvent.OutputObject
+    >;
+
+    "MigrationFinalized(uint256,bytes32,address)": TypedContractEvent<
+      MigrationFinalizedEvent.InputTuple,
+      MigrationFinalizedEvent.OutputTuple,
+      MigrationFinalizedEvent.OutputObject
+    >;
+    MigrationFinalized: TypedContractEvent<
+      MigrationFinalizedEvent.InputTuple,
+      MigrationFinalizedEvent.OutputTuple,
+      MigrationFinalizedEvent.OutputObject
+    >;
+
+    "MigrationStarted(uint256,bytes32,uint256)": TypedContractEvent<
+      MigrationStartedEvent.InputTuple,
+      MigrationStartedEvent.OutputTuple,
+      MigrationStartedEvent.OutputObject
+    >;
+    MigrationStarted: TypedContractEvent<
+      MigrationStartedEvent.InputTuple,
+      MigrationStartedEvent.OutputTuple,
+      MigrationStartedEvent.OutputObject
+    >;
+
     "NewAdmin(address,address)": TypedContractEvent<
       NewAdminEvent.InputTuple,
       NewAdminEvent.OutputTuple,
@@ -738,6 +1535,17 @@ export interface IBridgehub extends BaseContract {
       NewPendingAdminEvent.InputTuple,
       NewPendingAdminEvent.OutputTuple,
       NewPendingAdminEvent.OutputObject
+    >;
+
+    "SettlementLayerRegistered(uint256,bool)": TypedContractEvent<
+      SettlementLayerRegisteredEvent.InputTuple,
+      SettlementLayerRegisteredEvent.OutputTuple,
+      SettlementLayerRegisteredEvent.OutputObject
+    >;
+    SettlementLayerRegistered: TypedContractEvent<
+      SettlementLayerRegisteredEvent.InputTuple,
+      SettlementLayerRegisteredEvent.OutputTuple,
+      SettlementLayerRegisteredEvent.OutputObject
     >;
   };
 }

--- a/src/typechain/IL1AssetRouter.ts
+++ b/src/typechain/IL1AssetRouter.ts
@@ -49,46 +49,33 @@ export interface IL1AssetRouterInterface extends Interface {
   getFunction(
     nameOrSignature:
       | "BRIDGE_HUB"
-      | "ERA_CHAIN_ID"
-      | "L1_CHAIN_ID"
       | "L1_NULLIFIER"
       | "L1_WETH_TOKEN"
-      | "acceptOwnership"
-      | "assetDeploymentTracker"
       | "assetHandlerAddress"
       | "bridgeRecoverFailedTransfer(uint256,address,bytes32,bytes)"
       | "bridgeRecoverFailedTransfer(uint256,address,bytes32,bytes,bytes32,uint256,uint256,uint16,bytes32[])"
       | "bridgehubConfirmL2Transaction"
       | "bridgehubDeposit"
       | "bridgehubDepositBaseToken"
-      | "claimFailedDeposit"
       | "depositLegacyErc20Bridge"
       | "finalizeDeposit"
       | "finalizeWithdrawal"
       | "getDepositCalldata"
-      | "initialize"
       | "isWithdrawalFinalized"
-      | "legacyBridge"
+      | "l2BridgeAddress"
       | "nativeTokenVault"
-      | "owner"
-      | "pause"
-      | "paused"
-      | "pendingOwner"
-      | "renounceOwnership"
       | "setAssetDeploymentTracker"
       | "setAssetHandlerAddressThisChain"
       | "setL1Erc20Bridge"
       | "setNativeTokenVault"
       | "transferFundsToNTV"
-      | "transferOwnership"
-      | "unpause"
   ): FunctionFragment;
 
   getEvent(
     nameOrSignatureOrTopic:
+      | "AssetDeploymentTrackerRegistered"
       | "AssetDeploymentTrackerSet"
       | "AssetHandlerRegistered"
-      | "AssetHandlerRegisteredInitial"
       | "BridgehubDepositBaseTokenInitiated"
       | "BridgehubDepositFinalized"
       | "BridgehubDepositInitiated"
@@ -96,24 +83,11 @@ export interface IL1AssetRouterInterface extends Interface {
       | "BridgehubWithdrawalInitiated"
       | "ClaimedFailedDepositAssetRouter"
       | "DepositFinalizedAssetRouter"
-      | "Initialized"
       | "LegacyDepositInitiated"
-      | "OwnershipTransferStarted"
-      | "OwnershipTransferred"
-      | "Paused"
-      | "Unpaused"
   ): EventFragment;
 
   encodeFunctionData(
     functionFragment: "BRIDGE_HUB",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "ERA_CHAIN_ID",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "L1_CHAIN_ID",
     values?: undefined
   ): string;
   encodeFunctionData(
@@ -123,14 +97,6 @@ export interface IL1AssetRouterInterface extends Interface {
   encodeFunctionData(
     functionFragment: "L1_WETH_TOKEN",
     values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "acceptOwnership",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "assetDeploymentTracker",
-    values: [BytesLike]
   ): string;
   encodeFunctionData(
     functionFragment: "assetHandlerAddress",
@@ -167,20 +133,6 @@ export interface IL1AssetRouterInterface extends Interface {
     values: [BigNumberish, BytesLike, AddressLike, BigNumberish]
   ): string;
   encodeFunctionData(
-    functionFragment: "claimFailedDeposit",
-    values: [
-      BigNumberish,
-      AddressLike,
-      AddressLike,
-      BigNumberish,
-      BytesLike,
-      BigNumberish,
-      BigNumberish,
-      BigNumberish,
-      BytesLike[]
-    ]
-  ): string;
-  encodeFunctionData(
     functionFragment: "depositLegacyErc20Bridge",
     values: [
       AddressLike,
@@ -212,30 +164,15 @@ export interface IL1AssetRouterInterface extends Interface {
     values: [AddressLike, BytesLike, BytesLike]
   ): string;
   encodeFunctionData(
-    functionFragment: "initialize",
-    values: [AddressLike]
-  ): string;
-  encodeFunctionData(
     functionFragment: "isWithdrawalFinalized",
     values: [BigNumberish, BigNumberish, BigNumberish]
   ): string;
   encodeFunctionData(
-    functionFragment: "legacyBridge",
-    values?: undefined
+    functionFragment: "l2BridgeAddress",
+    values: [BigNumberish]
   ): string;
   encodeFunctionData(
     functionFragment: "nativeTokenVault",
-    values?: undefined
-  ): string;
-  encodeFunctionData(functionFragment: "owner", values?: undefined): string;
-  encodeFunctionData(functionFragment: "pause", values?: undefined): string;
-  encodeFunctionData(functionFragment: "paused", values?: undefined): string;
-  encodeFunctionData(
-    functionFragment: "pendingOwner",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "renounceOwnership",
     values?: undefined
   ): string;
   encodeFunctionData(
@@ -258,35 +195,14 @@ export interface IL1AssetRouterInterface extends Interface {
     functionFragment: "transferFundsToNTV",
     values: [BytesLike, BigNumberish, AddressLike]
   ): string;
-  encodeFunctionData(
-    functionFragment: "transferOwnership",
-    values: [AddressLike]
-  ): string;
-  encodeFunctionData(functionFragment: "unpause", values?: undefined): string;
 
   decodeFunctionResult(functionFragment: "BRIDGE_HUB", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "ERA_CHAIN_ID",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "L1_CHAIN_ID",
-    data: BytesLike
-  ): Result;
   decodeFunctionResult(
     functionFragment: "L1_NULLIFIER",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "L1_WETH_TOKEN",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "acceptOwnership",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "assetDeploymentTracker",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -314,10 +230,6 @@ export interface IL1AssetRouterInterface extends Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "claimFailedDeposit",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "depositLegacyErc20Bridge",
     data: BytesLike
   ): Result;
@@ -333,28 +245,16 @@ export interface IL1AssetRouterInterface extends Interface {
     functionFragment: "getDepositCalldata",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "initialize", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "isWithdrawalFinalized",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "legacyBridge",
+    functionFragment: "l2BridgeAddress",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "nativeTokenVault",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "pause", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "paused", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "pendingOwner",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "renounceOwnership",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -377,11 +277,28 @@ export interface IL1AssetRouterInterface extends Interface {
     functionFragment: "transferFundsToNTV",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(
-    functionFragment: "transferOwnership",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(functionFragment: "unpause", data: BytesLike): Result;
+}
+
+export namespace AssetDeploymentTrackerRegisteredEvent {
+  export type InputTuple = [
+    assetId: BytesLike,
+    additionalData: BytesLike,
+    assetDeploymentTracker: AddressLike
+  ];
+  export type OutputTuple = [
+    assetId: string,
+    additionalData: string,
+    assetDeploymentTracker: string
+  ];
+  export interface OutputObject {
+    assetId: string;
+    additionalData: string;
+    assetDeploymentTracker: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
 }
 
 export namespace AssetDeploymentTrackerSetEvent {
@@ -407,36 +324,14 @@ export namespace AssetDeploymentTrackerSetEvent {
 }
 
 export namespace AssetHandlerRegisteredEvent {
-  export type InputTuple = [assetId: BytesLike, _assetAddress: AddressLike];
-  export type OutputTuple = [assetId: string, _assetAddress: string];
-  export interface OutputObject {
-    assetId: string;
-    _assetAddress: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace AssetHandlerRegisteredInitialEvent {
   export type InputTuple = [
     assetId: BytesLike,
-    assetHandlerAddress: AddressLike,
-    additionalData: BytesLike,
-    assetDeploymentTracker: AddressLike
+    _assetHandlerAddress: AddressLike
   ];
-  export type OutputTuple = [
-    assetId: string,
-    assetHandlerAddress: string,
-    additionalData: string,
-    assetDeploymentTracker: string
-  ];
+  export type OutputTuple = [assetId: string, _assetHandlerAddress: string];
   export interface OutputObject {
     assetId: string;
-    assetHandlerAddress: string;
-    additionalData: string;
-    assetDeploymentTracker: string;
+    _assetHandlerAddress: string;
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
@@ -600,25 +495,13 @@ export namespace DepositFinalizedAssetRouterEvent {
   export type LogDescription = TypedLogDescription<Event>;
 }
 
-export namespace InitializedEvent {
-  export type InputTuple = [version: BigNumberish];
-  export type OutputTuple = [version: bigint];
-  export interface OutputObject {
-    version: bigint;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
 export namespace LegacyDepositInitiatedEvent {
   export type InputTuple = [
     chainId: BigNumberish,
     l2DepositTxHash: BytesLike,
     from: AddressLike,
     to: AddressLike,
-    l1Asset: AddressLike,
+    l1Token: AddressLike,
     amount: BigNumberish
   ];
   export type OutputTuple = [
@@ -626,7 +509,7 @@ export namespace LegacyDepositInitiatedEvent {
     l2DepositTxHash: string,
     from: string,
     to: string,
-    l1Asset: string,
+    l1Token: string,
     amount: bigint
   ];
   export interface OutputObject {
@@ -634,58 +517,8 @@ export namespace LegacyDepositInitiatedEvent {
     l2DepositTxHash: string;
     from: string;
     to: string;
-    l1Asset: string;
+    l1Token: string;
     amount: bigint;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace OwnershipTransferStartedEvent {
-  export type InputTuple = [previousOwner: AddressLike, newOwner: AddressLike];
-  export type OutputTuple = [previousOwner: string, newOwner: string];
-  export interface OutputObject {
-    previousOwner: string;
-    newOwner: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace OwnershipTransferredEvent {
-  export type InputTuple = [previousOwner: AddressLike, newOwner: AddressLike];
-  export type OutputTuple = [previousOwner: string, newOwner: string];
-  export interface OutputObject {
-    previousOwner: string;
-    newOwner: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace PausedEvent {
-  export type InputTuple = [account: AddressLike];
-  export type OutputTuple = [account: string];
-  export interface OutputObject {
-    account: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace UnpausedEvent {
-  export type InputTuple = [account: AddressLike];
-  export type OutputTuple = [account: string];
-  export interface OutputObject {
-    account: string;
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
@@ -738,24 +571,12 @@ export interface IL1AssetRouter extends BaseContract {
 
   BRIDGE_HUB: TypedContractMethod<[], [string], "view">;
 
-  ERA_CHAIN_ID: TypedContractMethod<[], [bigint], "view">;
-
-  L1_CHAIN_ID: TypedContractMethod<[], [bigint], "view">;
-
   L1_NULLIFIER: TypedContractMethod<[], [string], "view">;
 
   L1_WETH_TOKEN: TypedContractMethod<[], [string], "view">;
 
-  acceptOwnership: TypedContractMethod<[], [void], "nonpayable">;
-
-  assetDeploymentTracker: TypedContractMethod<
-    [assetId: BytesLike],
-    [string],
-    "view"
-  >;
-
   assetHandlerAddress: TypedContractMethod<
-    [assetId: BytesLike],
+    [_assetId: BytesLike],
     [string],
     "view"
   >;
@@ -815,22 +636,6 @@ export interface IL1AssetRouter extends BaseContract {
     "payable"
   >;
 
-  claimFailedDeposit: TypedContractMethod<
-    [
-      _chainId: BigNumberish,
-      _depositSender: AddressLike,
-      _l1Token: AddressLike,
-      _amount: BigNumberish,
-      _l2TxHash: BytesLike,
-      _l2BatchNumber: BigNumberish,
-      _l2MessageIndex: BigNumberish,
-      _l2TxNumberInBatch: BigNumberish,
-      _merkleProof: BytesLike[]
-    ],
-    [void],
-    "nonpayable"
-  >;
-
   depositLegacyErc20Bridge: TypedContractMethod<
     [
       _originalCaller: AddressLike,
@@ -848,7 +653,7 @@ export interface IL1AssetRouter extends BaseContract {
   finalizeDeposit: TypedContractMethod<
     [_chainId: BigNumberish, _assetId: BytesLike, _transferData: BytesLike],
     [void],
-    "nonpayable"
+    "payable"
   >;
 
   finalizeWithdrawal: TypedContractMethod<
@@ -870,8 +675,6 @@ export interface IL1AssetRouter extends BaseContract {
     "view"
   >;
 
-  initialize: TypedContractMethod<[_owner: AddressLike], [void], "nonpayable">;
-
   isWithdrawalFinalized: TypedContractMethod<
     [
       _chainId: BigNumberish,
@@ -882,19 +685,13 @@ export interface IL1AssetRouter extends BaseContract {
     "view"
   >;
 
-  legacyBridge: TypedContractMethod<[], [string], "view">;
+  l2BridgeAddress: TypedContractMethod<
+    [_chainId: BigNumberish],
+    [string],
+    "view"
+  >;
 
   nativeTokenVault: TypedContractMethod<[], [string], "view">;
-
-  owner: TypedContractMethod<[], [string], "view">;
-
-  pause: TypedContractMethod<[], [void], "nonpayable">;
-
-  paused: TypedContractMethod<[], [boolean], "view">;
-
-  pendingOwner: TypedContractMethod<[], [string], "view">;
-
-  renounceOwnership: TypedContractMethod<[], [void], "nonpayable">;
 
   setAssetDeploymentTracker: TypedContractMethod<
     [_assetRegistrationData: BytesLike, _assetDeploymentTracker: AddressLike],
@@ -926,14 +723,6 @@ export interface IL1AssetRouter extends BaseContract {
     "nonpayable"
   >;
 
-  transferOwnership: TypedContractMethod<
-    [newOwner: AddressLike],
-    [void],
-    "nonpayable"
-  >;
-
-  unpause: TypedContractMethod<[], [void], "nonpayable">;
-
   getFunction<T extends ContractMethod = ContractMethod>(
     key: string | FunctionFragment
   ): T;
@@ -942,26 +731,14 @@ export interface IL1AssetRouter extends BaseContract {
     nameOrSignature: "BRIDGE_HUB"
   ): TypedContractMethod<[], [string], "view">;
   getFunction(
-    nameOrSignature: "ERA_CHAIN_ID"
-  ): TypedContractMethod<[], [bigint], "view">;
-  getFunction(
-    nameOrSignature: "L1_CHAIN_ID"
-  ): TypedContractMethod<[], [bigint], "view">;
-  getFunction(
     nameOrSignature: "L1_NULLIFIER"
   ): TypedContractMethod<[], [string], "view">;
   getFunction(
     nameOrSignature: "L1_WETH_TOKEN"
   ): TypedContractMethod<[], [string], "view">;
   getFunction(
-    nameOrSignature: "acceptOwnership"
-  ): TypedContractMethod<[], [void], "nonpayable">;
-  getFunction(
-    nameOrSignature: "assetDeploymentTracker"
-  ): TypedContractMethod<[assetId: BytesLike], [string], "view">;
-  getFunction(
     nameOrSignature: "assetHandlerAddress"
-  ): TypedContractMethod<[assetId: BytesLike], [string], "view">;
+  ): TypedContractMethod<[_assetId: BytesLike], [string], "view">;
   getFunction(
     nameOrSignature: "bridgeRecoverFailedTransfer(uint256,address,bytes32,bytes)"
   ): TypedContractMethod<
@@ -1023,23 +800,6 @@ export interface IL1AssetRouter extends BaseContract {
     "payable"
   >;
   getFunction(
-    nameOrSignature: "claimFailedDeposit"
-  ): TypedContractMethod<
-    [
-      _chainId: BigNumberish,
-      _depositSender: AddressLike,
-      _l1Token: AddressLike,
-      _amount: BigNumberish,
-      _l2TxHash: BytesLike,
-      _l2BatchNumber: BigNumberish,
-      _l2MessageIndex: BigNumberish,
-      _l2TxNumberInBatch: BigNumberish,
-      _merkleProof: BytesLike[]
-    ],
-    [void],
-    "nonpayable"
-  >;
-  getFunction(
     nameOrSignature: "depositLegacyErc20Bridge"
   ): TypedContractMethod<
     [
@@ -1059,7 +819,7 @@ export interface IL1AssetRouter extends BaseContract {
   ): TypedContractMethod<
     [_chainId: BigNumberish, _assetId: BytesLike, _transferData: BytesLike],
     [void],
-    "nonpayable"
+    "payable"
   >;
   getFunction(
     nameOrSignature: "finalizeWithdrawal"
@@ -1083,9 +843,6 @@ export interface IL1AssetRouter extends BaseContract {
     "view"
   >;
   getFunction(
-    nameOrSignature: "initialize"
-  ): TypedContractMethod<[_owner: AddressLike], [void], "nonpayable">;
-  getFunction(
     nameOrSignature: "isWithdrawalFinalized"
   ): TypedContractMethod<
     [
@@ -1097,26 +854,11 @@ export interface IL1AssetRouter extends BaseContract {
     "view"
   >;
   getFunction(
-    nameOrSignature: "legacyBridge"
-  ): TypedContractMethod<[], [string], "view">;
+    nameOrSignature: "l2BridgeAddress"
+  ): TypedContractMethod<[_chainId: BigNumberish], [string], "view">;
   getFunction(
     nameOrSignature: "nativeTokenVault"
   ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "owner"
-  ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "pause"
-  ): TypedContractMethod<[], [void], "nonpayable">;
-  getFunction(
-    nameOrSignature: "paused"
-  ): TypedContractMethod<[], [boolean], "view">;
-  getFunction(
-    nameOrSignature: "pendingOwner"
-  ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "renounceOwnership"
-  ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
     nameOrSignature: "setAssetDeploymentTracker"
   ): TypedContractMethod<
@@ -1148,13 +890,14 @@ export interface IL1AssetRouter extends BaseContract {
     [boolean],
     "nonpayable"
   >;
-  getFunction(
-    nameOrSignature: "transferOwnership"
-  ): TypedContractMethod<[newOwner: AddressLike], [void], "nonpayable">;
-  getFunction(
-    nameOrSignature: "unpause"
-  ): TypedContractMethod<[], [void], "nonpayable">;
 
+  getEvent(
+    key: "AssetDeploymentTrackerRegistered"
+  ): TypedContractEvent<
+    AssetDeploymentTrackerRegisteredEvent.InputTuple,
+    AssetDeploymentTrackerRegisteredEvent.OutputTuple,
+    AssetDeploymentTrackerRegisteredEvent.OutputObject
+  >;
   getEvent(
     key: "AssetDeploymentTrackerSet"
   ): TypedContractEvent<
@@ -1168,13 +911,6 @@ export interface IL1AssetRouter extends BaseContract {
     AssetHandlerRegisteredEvent.InputTuple,
     AssetHandlerRegisteredEvent.OutputTuple,
     AssetHandlerRegisteredEvent.OutputObject
-  >;
-  getEvent(
-    key: "AssetHandlerRegisteredInitial"
-  ): TypedContractEvent<
-    AssetHandlerRegisteredInitialEvent.InputTuple,
-    AssetHandlerRegisteredInitialEvent.OutputTuple,
-    AssetHandlerRegisteredInitialEvent.OutputObject
   >;
   getEvent(
     key: "BridgehubDepositBaseTokenInitiated"
@@ -1226,49 +962,25 @@ export interface IL1AssetRouter extends BaseContract {
     DepositFinalizedAssetRouterEvent.OutputObject
   >;
   getEvent(
-    key: "Initialized"
-  ): TypedContractEvent<
-    InitializedEvent.InputTuple,
-    InitializedEvent.OutputTuple,
-    InitializedEvent.OutputObject
-  >;
-  getEvent(
     key: "LegacyDepositInitiated"
   ): TypedContractEvent<
     LegacyDepositInitiatedEvent.InputTuple,
     LegacyDepositInitiatedEvent.OutputTuple,
     LegacyDepositInitiatedEvent.OutputObject
   >;
-  getEvent(
-    key: "OwnershipTransferStarted"
-  ): TypedContractEvent<
-    OwnershipTransferStartedEvent.InputTuple,
-    OwnershipTransferStartedEvent.OutputTuple,
-    OwnershipTransferStartedEvent.OutputObject
-  >;
-  getEvent(
-    key: "OwnershipTransferred"
-  ): TypedContractEvent<
-    OwnershipTransferredEvent.InputTuple,
-    OwnershipTransferredEvent.OutputTuple,
-    OwnershipTransferredEvent.OutputObject
-  >;
-  getEvent(
-    key: "Paused"
-  ): TypedContractEvent<
-    PausedEvent.InputTuple,
-    PausedEvent.OutputTuple,
-    PausedEvent.OutputObject
-  >;
-  getEvent(
-    key: "Unpaused"
-  ): TypedContractEvent<
-    UnpausedEvent.InputTuple,
-    UnpausedEvent.OutputTuple,
-    UnpausedEvent.OutputObject
-  >;
 
   filters: {
+    "AssetDeploymentTrackerRegistered(bytes32,bytes32,address)": TypedContractEvent<
+      AssetDeploymentTrackerRegisteredEvent.InputTuple,
+      AssetDeploymentTrackerRegisteredEvent.OutputTuple,
+      AssetDeploymentTrackerRegisteredEvent.OutputObject
+    >;
+    AssetDeploymentTrackerRegistered: TypedContractEvent<
+      AssetDeploymentTrackerRegisteredEvent.InputTuple,
+      AssetDeploymentTrackerRegisteredEvent.OutputTuple,
+      AssetDeploymentTrackerRegisteredEvent.OutputObject
+    >;
+
     "AssetDeploymentTrackerSet(bytes32,address,bytes32)": TypedContractEvent<
       AssetDeploymentTrackerSetEvent.InputTuple,
       AssetDeploymentTrackerSetEvent.OutputTuple,
@@ -1289,17 +1001,6 @@ export interface IL1AssetRouter extends BaseContract {
       AssetHandlerRegisteredEvent.InputTuple,
       AssetHandlerRegisteredEvent.OutputTuple,
       AssetHandlerRegisteredEvent.OutputObject
-    >;
-
-    "AssetHandlerRegisteredInitial(bytes32,address,bytes32,address)": TypedContractEvent<
-      AssetHandlerRegisteredInitialEvent.InputTuple,
-      AssetHandlerRegisteredInitialEvent.OutputTuple,
-      AssetHandlerRegisteredInitialEvent.OutputObject
-    >;
-    AssetHandlerRegisteredInitial: TypedContractEvent<
-      AssetHandlerRegisteredInitialEvent.InputTuple,
-      AssetHandlerRegisteredInitialEvent.OutputTuple,
-      AssetHandlerRegisteredInitialEvent.OutputObject
     >;
 
     "BridgehubDepositBaseTokenInitiated(uint256,address,bytes32,uint256)": TypedContractEvent<
@@ -1379,17 +1080,6 @@ export interface IL1AssetRouter extends BaseContract {
       DepositFinalizedAssetRouterEvent.OutputObject
     >;
 
-    "Initialized(uint8)": TypedContractEvent<
-      InitializedEvent.InputTuple,
-      InitializedEvent.OutputTuple,
-      InitializedEvent.OutputObject
-    >;
-    Initialized: TypedContractEvent<
-      InitializedEvent.InputTuple,
-      InitializedEvent.OutputTuple,
-      InitializedEvent.OutputObject
-    >;
-
     "LegacyDepositInitiated(uint256,bytes32,address,address,address,uint256)": TypedContractEvent<
       LegacyDepositInitiatedEvent.InputTuple,
       LegacyDepositInitiatedEvent.OutputTuple,
@@ -1399,50 +1089,6 @@ export interface IL1AssetRouter extends BaseContract {
       LegacyDepositInitiatedEvent.InputTuple,
       LegacyDepositInitiatedEvent.OutputTuple,
       LegacyDepositInitiatedEvent.OutputObject
-    >;
-
-    "OwnershipTransferStarted(address,address)": TypedContractEvent<
-      OwnershipTransferStartedEvent.InputTuple,
-      OwnershipTransferStartedEvent.OutputTuple,
-      OwnershipTransferStartedEvent.OutputObject
-    >;
-    OwnershipTransferStarted: TypedContractEvent<
-      OwnershipTransferStartedEvent.InputTuple,
-      OwnershipTransferStartedEvent.OutputTuple,
-      OwnershipTransferStartedEvent.OutputObject
-    >;
-
-    "OwnershipTransferred(address,address)": TypedContractEvent<
-      OwnershipTransferredEvent.InputTuple,
-      OwnershipTransferredEvent.OutputTuple,
-      OwnershipTransferredEvent.OutputObject
-    >;
-    OwnershipTransferred: TypedContractEvent<
-      OwnershipTransferredEvent.InputTuple,
-      OwnershipTransferredEvent.OutputTuple,
-      OwnershipTransferredEvent.OutputObject
-    >;
-
-    "Paused(address)": TypedContractEvent<
-      PausedEvent.InputTuple,
-      PausedEvent.OutputTuple,
-      PausedEvent.OutputObject
-    >;
-    Paused: TypedContractEvent<
-      PausedEvent.InputTuple,
-      PausedEvent.OutputTuple,
-      PausedEvent.OutputObject
-    >;
-
-    "Unpaused(address)": TypedContractEvent<
-      UnpausedEvent.InputTuple,
-      UnpausedEvent.OutputTuple,
-      UnpausedEvent.OutputObject
-    >;
-    Unpaused: TypedContractEvent<
-      UnpausedEvent.InputTuple,
-      UnpausedEvent.OutputTuple,
-      UnpausedEvent.OutputObject
     >;
   };
 }

--- a/src/typechain/IL1Nullifier.ts
+++ b/src/typechain/IL1Nullifier.ts
@@ -55,72 +55,28 @@ export interface IL1NullifierInterface extends Interface {
   getFunction(
     nameOrSignature:
       | "BRIDGE_HUB"
-      | "__DEPRECATED_admin"
-      | "__DEPRECATED_chainBalance"
-      | "__DEPRECATED_l2BridgeAddress"
-      | "__DEPRECATED_pendingAdmin"
-      | "acceptOwnership"
       | "bridgeRecoverFailedTransfer"
       | "bridgehubConfirmL2TransactionForwarded"
       | "chainBalance"
       | "claimFailedDeposit"
       | "claimFailedDepositLegacyErc20Bridge"
       | "depositHappened"
-      | "encodeTxDataHash"
       | "finalizeDeposit"
       | "finalizeWithdrawal"
-      | "initialize"
       | "isWithdrawalFinalized"
-      | "l1AssetRouter"
       | "l1NativeTokenVault"
       | "l2BridgeAddress"
       | "legacyBridge"
       | "nullifyChainBalanceByNTV"
-      | "owner"
-      | "pause"
-      | "paused"
-      | "pendingOwner"
-      | "renounceOwnership"
       | "setL1AssetRouter"
-      | "setL1Erc20Bridge"
       | "setL1NativeTokenVault"
-      | "transferOwnership"
       | "transferTokenToNTV"
-      | "unpause"
   ): FunctionFragment;
 
-  getEvent(
-    nameOrSignatureOrTopic:
-      | "BridgehubDepositFinalized"
-      | "Initialized"
-      | "OwnershipTransferStarted"
-      | "OwnershipTransferred"
-      | "Paused"
-      | "Unpaused"
-  ): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "BridgehubDepositFinalized"): EventFragment;
 
   encodeFunctionData(
     functionFragment: "BRIDGE_HUB",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "__DEPRECATED_admin",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "__DEPRECATED_chainBalance",
-    values: [BigNumberish, AddressLike]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "__DEPRECATED_l2BridgeAddress",
-    values: [BigNumberish]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "__DEPRECATED_pendingAdmin",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "acceptOwnership",
     values?: undefined
   ): string;
   encodeFunctionData(
@@ -177,10 +133,6 @@ export interface IL1NullifierInterface extends Interface {
     values: [BigNumberish, BytesLike]
   ): string;
   encodeFunctionData(
-    functionFragment: "encodeTxDataHash",
-    values: [BytesLike, AddressLike, BytesLike, BytesLike]
-  ): string;
-  encodeFunctionData(
     functionFragment: "finalizeDeposit",
     values: [FinalizeL1DepositParamsStruct]
   ): string;
@@ -196,22 +148,8 @@ export interface IL1NullifierInterface extends Interface {
     ]
   ): string;
   encodeFunctionData(
-    functionFragment: "initialize",
-    values: [
-      AddressLike,
-      BigNumberish,
-      BigNumberish,
-      BigNumberish,
-      BigNumberish
-    ]
-  ): string;
-  encodeFunctionData(
     functionFragment: "isWithdrawalFinalized",
     values: [BigNumberish, BigNumberish, BigNumberish]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "l1AssetRouter",
-    values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "l1NativeTokenVault",
@@ -229,23 +167,8 @@ export interface IL1NullifierInterface extends Interface {
     functionFragment: "nullifyChainBalanceByNTV",
     values: [BigNumberish, AddressLike]
   ): string;
-  encodeFunctionData(functionFragment: "owner", values?: undefined): string;
-  encodeFunctionData(functionFragment: "pause", values?: undefined): string;
-  encodeFunctionData(functionFragment: "paused", values?: undefined): string;
-  encodeFunctionData(
-    functionFragment: "pendingOwner",
-    values?: undefined
-  ): string;
-  encodeFunctionData(
-    functionFragment: "renounceOwnership",
-    values?: undefined
-  ): string;
   encodeFunctionData(
     functionFragment: "setL1AssetRouter",
-    values: [AddressLike]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "setL1Erc20Bridge",
     values: [AddressLike]
   ): string;
   encodeFunctionData(
@@ -253,36 +176,11 @@ export interface IL1NullifierInterface extends Interface {
     values: [AddressLike]
   ): string;
   encodeFunctionData(
-    functionFragment: "transferOwnership",
-    values: [AddressLike]
-  ): string;
-  encodeFunctionData(
     functionFragment: "transferTokenToNTV",
     values: [AddressLike]
   ): string;
-  encodeFunctionData(functionFragment: "unpause", values?: undefined): string;
 
   decodeFunctionResult(functionFragment: "BRIDGE_HUB", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "__DEPRECATED_admin",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "__DEPRECATED_chainBalance",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "__DEPRECATED_l2BridgeAddress",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "__DEPRECATED_pendingAdmin",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "acceptOwnership",
-    data: BytesLike
-  ): Result;
   decodeFunctionResult(
     functionFragment: "bridgeRecoverFailedTransfer",
     data: BytesLike
@@ -308,10 +206,6 @@ export interface IL1NullifierInterface extends Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "encodeTxDataHash",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "finalizeDeposit",
     data: BytesLike
   ): Result;
@@ -319,13 +213,8 @@ export interface IL1NullifierInterface extends Interface {
     functionFragment: "finalizeWithdrawal",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "initialize", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "isWithdrawalFinalized",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "l1AssetRouter",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -344,23 +233,8 @@ export interface IL1NullifierInterface extends Interface {
     functionFragment: "nullifyChainBalanceByNTV",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "pause", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "paused", data: BytesLike): Result;
-  decodeFunctionResult(
-    functionFragment: "pendingOwner",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "renounceOwnership",
-    data: BytesLike
-  ): Result;
   decodeFunctionResult(
     functionFragment: "setL1AssetRouter",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "setL1Erc20Bridge",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -368,14 +242,9 @@ export interface IL1NullifierInterface extends Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
-    functionFragment: "transferOwnership",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
     functionFragment: "transferTokenToNTV",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "unpause", data: BytesLike): Result;
 }
 
 export namespace BridgehubDepositFinalizedEvent {
@@ -393,68 +262,6 @@ export namespace BridgehubDepositFinalizedEvent {
     chainId: bigint;
     txDataHash: string;
     l2DepositTxHash: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace InitializedEvent {
-  export type InputTuple = [version: BigNumberish];
-  export type OutputTuple = [version: bigint];
-  export interface OutputObject {
-    version: bigint;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace OwnershipTransferStartedEvent {
-  export type InputTuple = [previousOwner: AddressLike, newOwner: AddressLike];
-  export type OutputTuple = [previousOwner: string, newOwner: string];
-  export interface OutputObject {
-    previousOwner: string;
-    newOwner: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace OwnershipTransferredEvent {
-  export type InputTuple = [previousOwner: AddressLike, newOwner: AddressLike];
-  export type OutputTuple = [previousOwner: string, newOwner: string];
-  export interface OutputObject {
-    previousOwner: string;
-    newOwner: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace PausedEvent {
-  export type InputTuple = [account: AddressLike];
-  export type OutputTuple = [account: string];
-  export interface OutputObject {
-    account: string;
-  }
-  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
-  export type Filter = TypedDeferredTopicFilter<Event>;
-  export type Log = TypedEventLog<Event>;
-  export type LogDescription = TypedLogDescription<Event>;
-}
-
-export namespace UnpausedEvent {
-  export type InputTuple = [account: AddressLike];
-  export type OutputTuple = [account: string];
-  export interface OutputObject {
-    account: string;
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
@@ -506,24 +313,6 @@ export interface IL1Nullifier extends BaseContract {
   ): Promise<this>;
 
   BRIDGE_HUB: TypedContractMethod<[], [string], "view">;
-
-  __DEPRECATED_admin: TypedContractMethod<[], [string], "view">;
-
-  __DEPRECATED_chainBalance: TypedContractMethod<
-    [chainId: BigNumberish, l1Token: AddressLike],
-    [bigint],
-    "view"
-  >;
-
-  __DEPRECATED_l2BridgeAddress: TypedContractMethod<
-    [chainId: BigNumberish],
-    [string],
-    "view"
-  >;
-
-  __DEPRECATED_pendingAdmin: TypedContractMethod<[], [string], "view">;
-
-  acceptOwnership: TypedContractMethod<[], [void], "nonpayable">;
 
   bridgeRecoverFailedTransfer: TypedContractMethod<
     [
@@ -585,18 +374,7 @@ export interface IL1Nullifier extends BaseContract {
   >;
 
   depositHappened: TypedContractMethod<
-    [chainId: BigNumberish, l2DepositTxHash: BytesLike],
-    [string],
-    "view"
-  >;
-
-  encodeTxDataHash: TypedContractMethod<
-    [
-      _encodingVersion: BytesLike,
-      _originalCaller: AddressLike,
-      _assetId: BytesLike,
-      _transferData: BytesLike
-    ],
+    [_chainId: BigNumberish, _l2TxHash: BytesLike],
     [string],
     "view"
   >;
@@ -620,29 +398,15 @@ export interface IL1Nullifier extends BaseContract {
     "nonpayable"
   >;
 
-  initialize: TypedContractMethod<
-    [
-      _owner: AddressLike,
-      _eraPostDiamondUpgradeFirstBatch: BigNumberish,
-      _eraPostLegacyBridgeUpgradeFirstBatch: BigNumberish,
-      _eraLegacyBridgeLastDepositBatch: BigNumberish,
-      _eraLegacyBridgeLastDepositTxNumber: BigNumberish
-    ],
-    [void],
-    "nonpayable"
-  >;
-
   isWithdrawalFinalized: TypedContractMethod<
     [
-      chainId: BigNumberish,
-      l2BatchNumber: BigNumberish,
-      l2ToL1MessageNumber: BigNumberish
+      _chainId: BigNumberish,
+      _l2BatchNumber: BigNumberish,
+      _l2MessageIndex: BigNumberish
     ],
     [boolean],
     "view"
   >;
-
-  l1AssetRouter: TypedContractMethod<[], [string], "view">;
 
   l1NativeTokenVault: TypedContractMethod<[], [string], "view">;
 
@@ -660,36 +424,14 @@ export interface IL1Nullifier extends BaseContract {
     "nonpayable"
   >;
 
-  owner: TypedContractMethod<[], [string], "view">;
-
-  pause: TypedContractMethod<[], [void], "nonpayable">;
-
-  paused: TypedContractMethod<[], [boolean], "view">;
-
-  pendingOwner: TypedContractMethod<[], [string], "view">;
-
-  renounceOwnership: TypedContractMethod<[], [void], "nonpayable">;
-
   setL1AssetRouter: TypedContractMethod<
     [_l1AssetRouter: AddressLike],
     [void],
     "nonpayable"
   >;
 
-  setL1Erc20Bridge: TypedContractMethod<
-    [_legacyBridge: AddressLike],
-    [void],
-    "nonpayable"
-  >;
-
   setL1NativeTokenVault: TypedContractMethod<
-    [_l1NativeTokenVault: AddressLike],
-    [void],
-    "nonpayable"
-  >;
-
-  transferOwnership: TypedContractMethod<
-    [newOwner: AddressLike],
+    [_nativeTokenVault: AddressLike],
     [void],
     "nonpayable"
   >;
@@ -700,8 +442,6 @@ export interface IL1Nullifier extends BaseContract {
     "nonpayable"
   >;
 
-  unpause: TypedContractMethod<[], [void], "nonpayable">;
-
   getFunction<T extends ContractMethod = ContractMethod>(
     key: string | FunctionFragment
   ): T;
@@ -709,25 +449,6 @@ export interface IL1Nullifier extends BaseContract {
   getFunction(
     nameOrSignature: "BRIDGE_HUB"
   ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "__DEPRECATED_admin"
-  ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "__DEPRECATED_chainBalance"
-  ): TypedContractMethod<
-    [chainId: BigNumberish, l1Token: AddressLike],
-    [bigint],
-    "view"
-  >;
-  getFunction(
-    nameOrSignature: "__DEPRECATED_l2BridgeAddress"
-  ): TypedContractMethod<[chainId: BigNumberish], [string], "view">;
-  getFunction(
-    nameOrSignature: "__DEPRECATED_pendingAdmin"
-  ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "acceptOwnership"
-  ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
     nameOrSignature: "bridgeRecoverFailedTransfer"
   ): TypedContractMethod<
@@ -795,19 +516,7 @@ export interface IL1Nullifier extends BaseContract {
   getFunction(
     nameOrSignature: "depositHappened"
   ): TypedContractMethod<
-    [chainId: BigNumberish, l2DepositTxHash: BytesLike],
-    [string],
-    "view"
-  >;
-  getFunction(
-    nameOrSignature: "encodeTxDataHash"
-  ): TypedContractMethod<
-    [
-      _encodingVersion: BytesLike,
-      _originalCaller: AddressLike,
-      _assetId: BytesLike,
-      _transferData: BytesLike
-    ],
+    [_chainId: BigNumberish, _l2TxHash: BytesLike],
     [string],
     "view"
   >;
@@ -833,32 +542,16 @@ export interface IL1Nullifier extends BaseContract {
     "nonpayable"
   >;
   getFunction(
-    nameOrSignature: "initialize"
-  ): TypedContractMethod<
-    [
-      _owner: AddressLike,
-      _eraPostDiamondUpgradeFirstBatch: BigNumberish,
-      _eraPostLegacyBridgeUpgradeFirstBatch: BigNumberish,
-      _eraLegacyBridgeLastDepositBatch: BigNumberish,
-      _eraLegacyBridgeLastDepositTxNumber: BigNumberish
-    ],
-    [void],
-    "nonpayable"
-  >;
-  getFunction(
     nameOrSignature: "isWithdrawalFinalized"
   ): TypedContractMethod<
     [
-      chainId: BigNumberish,
-      l2BatchNumber: BigNumberish,
-      l2ToL1MessageNumber: BigNumberish
+      _chainId: BigNumberish,
+      _l2BatchNumber: BigNumberish,
+      _l2MessageIndex: BigNumberish
     ],
     [boolean],
     "view"
   >;
-  getFunction(
-    nameOrSignature: "l1AssetRouter"
-  ): TypedContractMethod<[], [string], "view">;
   getFunction(
     nameOrSignature: "l1NativeTokenVault"
   ): TypedContractMethod<[], [string], "view">;
@@ -876,42 +569,18 @@ export interface IL1Nullifier extends BaseContract {
     "nonpayable"
   >;
   getFunction(
-    nameOrSignature: "owner"
-  ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "pause"
-  ): TypedContractMethod<[], [void], "nonpayable">;
-  getFunction(
-    nameOrSignature: "paused"
-  ): TypedContractMethod<[], [boolean], "view">;
-  getFunction(
-    nameOrSignature: "pendingOwner"
-  ): TypedContractMethod<[], [string], "view">;
-  getFunction(
-    nameOrSignature: "renounceOwnership"
-  ): TypedContractMethod<[], [void], "nonpayable">;
-  getFunction(
     nameOrSignature: "setL1AssetRouter"
   ): TypedContractMethod<[_l1AssetRouter: AddressLike], [void], "nonpayable">;
   getFunction(
-    nameOrSignature: "setL1Erc20Bridge"
-  ): TypedContractMethod<[_legacyBridge: AddressLike], [void], "nonpayable">;
-  getFunction(
     nameOrSignature: "setL1NativeTokenVault"
   ): TypedContractMethod<
-    [_l1NativeTokenVault: AddressLike],
+    [_nativeTokenVault: AddressLike],
     [void],
     "nonpayable"
   >;
   getFunction(
-    nameOrSignature: "transferOwnership"
-  ): TypedContractMethod<[newOwner: AddressLike], [void], "nonpayable">;
-  getFunction(
     nameOrSignature: "transferTokenToNTV"
   ): TypedContractMethod<[_token: AddressLike], [void], "nonpayable">;
-  getFunction(
-    nameOrSignature: "unpause"
-  ): TypedContractMethod<[], [void], "nonpayable">;
 
   getEvent(
     key: "BridgehubDepositFinalized"
@@ -919,41 +588,6 @@ export interface IL1Nullifier extends BaseContract {
     BridgehubDepositFinalizedEvent.InputTuple,
     BridgehubDepositFinalizedEvent.OutputTuple,
     BridgehubDepositFinalizedEvent.OutputObject
-  >;
-  getEvent(
-    key: "Initialized"
-  ): TypedContractEvent<
-    InitializedEvent.InputTuple,
-    InitializedEvent.OutputTuple,
-    InitializedEvent.OutputObject
-  >;
-  getEvent(
-    key: "OwnershipTransferStarted"
-  ): TypedContractEvent<
-    OwnershipTransferStartedEvent.InputTuple,
-    OwnershipTransferStartedEvent.OutputTuple,
-    OwnershipTransferStartedEvent.OutputObject
-  >;
-  getEvent(
-    key: "OwnershipTransferred"
-  ): TypedContractEvent<
-    OwnershipTransferredEvent.InputTuple,
-    OwnershipTransferredEvent.OutputTuple,
-    OwnershipTransferredEvent.OutputObject
-  >;
-  getEvent(
-    key: "Paused"
-  ): TypedContractEvent<
-    PausedEvent.InputTuple,
-    PausedEvent.OutputTuple,
-    PausedEvent.OutputObject
-  >;
-  getEvent(
-    key: "Unpaused"
-  ): TypedContractEvent<
-    UnpausedEvent.InputTuple,
-    UnpausedEvent.OutputTuple,
-    UnpausedEvent.OutputObject
   >;
 
   filters: {
@@ -966,61 +600,6 @@ export interface IL1Nullifier extends BaseContract {
       BridgehubDepositFinalizedEvent.InputTuple,
       BridgehubDepositFinalizedEvent.OutputTuple,
       BridgehubDepositFinalizedEvent.OutputObject
-    >;
-
-    "Initialized(uint8)": TypedContractEvent<
-      InitializedEvent.InputTuple,
-      InitializedEvent.OutputTuple,
-      InitializedEvent.OutputObject
-    >;
-    Initialized: TypedContractEvent<
-      InitializedEvent.InputTuple,
-      InitializedEvent.OutputTuple,
-      InitializedEvent.OutputObject
-    >;
-
-    "OwnershipTransferStarted(address,address)": TypedContractEvent<
-      OwnershipTransferStartedEvent.InputTuple,
-      OwnershipTransferStartedEvent.OutputTuple,
-      OwnershipTransferStartedEvent.OutputObject
-    >;
-    OwnershipTransferStarted: TypedContractEvent<
-      OwnershipTransferStartedEvent.InputTuple,
-      OwnershipTransferStartedEvent.OutputTuple,
-      OwnershipTransferStartedEvent.OutputObject
-    >;
-
-    "OwnershipTransferred(address,address)": TypedContractEvent<
-      OwnershipTransferredEvent.InputTuple,
-      OwnershipTransferredEvent.OutputTuple,
-      OwnershipTransferredEvent.OutputObject
-    >;
-    OwnershipTransferred: TypedContractEvent<
-      OwnershipTransferredEvent.InputTuple,
-      OwnershipTransferredEvent.OutputTuple,
-      OwnershipTransferredEvent.OutputObject
-    >;
-
-    "Paused(address)": TypedContractEvent<
-      PausedEvent.InputTuple,
-      PausedEvent.OutputTuple,
-      PausedEvent.OutputObject
-    >;
-    Paused: TypedContractEvent<
-      PausedEvent.InputTuple,
-      PausedEvent.OutputTuple,
-      PausedEvent.OutputObject
-    >;
-
-    "Unpaused(address)": TypedContractEvent<
-      UnpausedEvent.InputTuple,
-      UnpausedEvent.OutputTuple,
-      UnpausedEvent.OutputObject
-    >;
-    Unpaused: TypedContractEvent<
-      UnpausedEvent.InputTuple,
-      UnpausedEvent.OutputTuple,
-      UnpausedEvent.OutputObject
     >;
   };
 }

--- a/src/typechain/IL2NativeTokenVault.ts
+++ b/src/typechain/IL2NativeTokenVault.ts
@@ -27,22 +27,46 @@ export interface IL2NativeTokenVaultInterface extends Interface {
   getFunction(
     nameOrSignature:
       | "ASSET_ROUTER"
+      | "BASE_TOKEN_ASSET_ID"
+      | "L1_CHAIN_ID"
+      | "L2_LEGACY_SHARED_BRIDGE"
       | "WETH_TOKEN"
+      | "acceptOwnership"
       | "assetId"
-      | "calculateAssetId"
+      | "bridgeBurn"
+      | "bridgeMint"
+      | "bridgedTokenBeacon"
       | "calculateCreate2TokenAddress"
+      | "ensureTokenIsRegistered"
       | "getERC20Getters"
       | "l2TokenAddress"
       | "originChainId"
+      | "owner"
+      | "pause"
+      | "paused"
+      | "pendingOwner"
       | "registerToken"
+      | "renounceOwnership"
+      | "setLegacyTokenAssetId"
       | "tokenAddress"
+      | "tokenDataOriginChainId"
+      | "transferOwnership"
+      | "tryRegisterTokenFromBurnData"
+      | "unpause"
   ): FunctionFragment;
 
   getEvent(
     nameOrSignatureOrTopic:
+      | "BridgeBurn"
+      | "BridgeMint"
       | "BridgedTokenBeaconUpdated"
       | "FinalizeDeposit"
+      | "Initialized"
       | "L2TokenBeaconUpdated"
+      | "OwnershipTransferStarted"
+      | "OwnershipTransferred"
+      | "Paused"
+      | "Unpaused"
       | "WithdrawalInitiated"
   ): EventFragment;
 
@@ -51,7 +75,23 @@ export interface IL2NativeTokenVaultInterface extends Interface {
     values?: undefined
   ): string;
   encodeFunctionData(
+    functionFragment: "BASE_TOKEN_ASSET_ID",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "L1_CHAIN_ID",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "L2_LEGACY_SHARED_BRIDGE",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
     functionFragment: "WETH_TOKEN",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "acceptOwnership",
     values?: undefined
   ): string;
   encodeFunctionData(
@@ -59,12 +99,24 @@ export interface IL2NativeTokenVaultInterface extends Interface {
     values: [AddressLike]
   ): string;
   encodeFunctionData(
-    functionFragment: "calculateAssetId",
-    values: [BigNumberish, AddressLike]
+    functionFragment: "bridgeBurn",
+    values: [BigNumberish, BigNumberish, BytesLike, AddressLike, BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "bridgeMint",
+    values: [BigNumberish, BytesLike, BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "bridgedTokenBeacon",
+    values?: undefined
   ): string;
   encodeFunctionData(
     functionFragment: "calculateCreate2TokenAddress",
     values: [BigNumberish, AddressLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "ensureTokenIsRegistered",
+    values: [AddressLike]
   ): string;
   encodeFunctionData(
     functionFragment: "getERC20Getters",
@@ -78,27 +130,77 @@ export interface IL2NativeTokenVaultInterface extends Interface {
     functionFragment: "originChainId",
     values: [BytesLike]
   ): string;
+  encodeFunctionData(functionFragment: "owner", values?: undefined): string;
+  encodeFunctionData(functionFragment: "pause", values?: undefined): string;
+  encodeFunctionData(functionFragment: "paused", values?: undefined): string;
+  encodeFunctionData(
+    functionFragment: "pendingOwner",
+    values?: undefined
+  ): string;
   encodeFunctionData(
     functionFragment: "registerToken",
+    values: [AddressLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "renounceOwnership",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setLegacyTokenAssetId",
     values: [AddressLike]
   ): string;
   encodeFunctionData(
     functionFragment: "tokenAddress",
     values: [BytesLike]
   ): string;
+  encodeFunctionData(
+    functionFragment: "tokenDataOriginChainId",
+    values: [BytesLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "transferOwnership",
+    values: [AddressLike]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "tryRegisterTokenFromBurnData",
+    values: [BytesLike, BytesLike]
+  ): string;
+  encodeFunctionData(functionFragment: "unpause", values?: undefined): string;
 
   decodeFunctionResult(
     functionFragment: "ASSET_ROUTER",
     data: BytesLike
   ): Result;
-  decodeFunctionResult(functionFragment: "WETH_TOKEN", data: BytesLike): Result;
-  decodeFunctionResult(functionFragment: "assetId", data: BytesLike): Result;
   decodeFunctionResult(
-    functionFragment: "calculateAssetId",
+    functionFragment: "BASE_TOKEN_ASSET_ID",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "L1_CHAIN_ID",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "L2_LEGACY_SHARED_BRIDGE",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(functionFragment: "WETH_TOKEN", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "acceptOwnership",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(functionFragment: "assetId", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "bridgeBurn", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "bridgeMint", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "bridgedTokenBeacon",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "calculateCreate2TokenAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "ensureTokenIsRegistered",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -113,14 +215,95 @@ export interface IL2NativeTokenVaultInterface extends Interface {
     functionFragment: "originChainId",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "owner", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "pause", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "paused", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "pendingOwner",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "registerToken",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "renounceOwnership",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setLegacyTokenAssetId",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "tokenAddress",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(
+    functionFragment: "tokenDataOriginChainId",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "transferOwnership",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "tryRegisterTokenFromBurnData",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(functionFragment: "unpause", data: BytesLike): Result;
+}
+
+export namespace BridgeBurnEvent {
+  export type InputTuple = [
+    chainId: BigNumberish,
+    assetId: BytesLike,
+    sender: AddressLike,
+    receiver: AddressLike,
+    amount: BigNumberish
+  ];
+  export type OutputTuple = [
+    chainId: bigint,
+    assetId: string,
+    sender: string,
+    receiver: string,
+    amount: bigint
+  ];
+  export interface OutputObject {
+    chainId: bigint;
+    assetId: string;
+    sender: string;
+    receiver: string;
+    amount: bigint;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace BridgeMintEvent {
+  export type InputTuple = [
+    chainId: BigNumberish,
+    assetId: BytesLike,
+    receiver: AddressLike,
+    amount: BigNumberish
+  ];
+  export type OutputTuple = [
+    chainId: bigint,
+    assetId: string,
+    receiver: string,
+    amount: bigint
+  ];
+  export interface OutputObject {
+    chainId: bigint;
+    assetId: string;
+    receiver: string;
+    amount: bigint;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
 }
 
 export namespace BridgedTokenBeaconUpdatedEvent {
@@ -167,6 +350,18 @@ export namespace FinalizeDepositEvent {
   export type LogDescription = TypedLogDescription<Event>;
 }
 
+export namespace InitializedEvent {
+  export type InputTuple = [version: BigNumberish];
+  export type OutputTuple = [version: bigint];
+  export interface OutputObject {
+    version: bigint;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
 export namespace L2TokenBeaconUpdatedEvent {
   export type InputTuple = [
     l2TokenBeacon: AddressLike,
@@ -179,6 +374,56 @@ export namespace L2TokenBeaconUpdatedEvent {
   export interface OutputObject {
     l2TokenBeacon: string;
     l2TokenProxyBytecodeHash: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace OwnershipTransferStartedEvent {
+  export type InputTuple = [previousOwner: AddressLike, newOwner: AddressLike];
+  export type OutputTuple = [previousOwner: string, newOwner: string];
+  export interface OutputObject {
+    previousOwner: string;
+    newOwner: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace OwnershipTransferredEvent {
+  export type InputTuple = [previousOwner: AddressLike, newOwner: AddressLike];
+  export type OutputTuple = [previousOwner: string, newOwner: string];
+  export interface OutputObject {
+    previousOwner: string;
+    newOwner: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace PausedEvent {
+  export type InputTuple = [account: AddressLike];
+  export type OutputTuple = [account: string];
+  export interface OutputObject {
+    account: string;
+  }
+  export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
+  export type Filter = TypedDeferredTopicFilter<Event>;
+  export type Log = TypedEventLog<Event>;
+  export type LogDescription = TypedLogDescription<Event>;
+}
+
+export namespace UnpausedEvent {
+  export type InputTuple = [account: AddressLike];
+  export type OutputTuple = [account: string];
+  export interface OutputObject {
+    account: string;
   }
   export type Event = TypedContractEvent<InputTuple, OutputTuple, OutputObject>;
   export type Filter = TypedDeferredTopicFilter<Event>;
@@ -256,20 +501,48 @@ export interface IL2NativeTokenVault extends BaseContract {
 
   ASSET_ROUTER: TypedContractMethod<[], [string], "view">;
 
+  BASE_TOKEN_ASSET_ID: TypedContractMethod<[], [string], "view">;
+
+  L1_CHAIN_ID: TypedContractMethod<[], [bigint], "view">;
+
+  L2_LEGACY_SHARED_BRIDGE: TypedContractMethod<[], [string], "view">;
+
   WETH_TOKEN: TypedContractMethod<[], [string], "view">;
 
-  assetId: TypedContractMethod<[token: AddressLike], [string], "view">;
+  acceptOwnership: TypedContractMethod<[], [void], "nonpayable">;
 
-  calculateAssetId: TypedContractMethod<
-    [_chainId: BigNumberish, _tokenAddress: AddressLike],
+  assetId: TypedContractMethod<[tokenAddress: AddressLike], [string], "view">;
+
+  bridgeBurn: TypedContractMethod<
+    [
+      _chainId: BigNumberish,
+      _l2MsgValue: BigNumberish,
+      _assetId: BytesLike,
+      _originalCaller: AddressLike,
+      _data: BytesLike
+    ],
+    [string],
+    "payable"
+  >;
+
+  bridgeMint: TypedContractMethod<
+    [_chainId: BigNumberish, _assetId: BytesLike, _data: BytesLike],
+    [void],
+    "payable"
+  >;
+
+  bridgedTokenBeacon: TypedContractMethod<[], [string], "view">;
+
+  calculateCreate2TokenAddress: TypedContractMethod<
+    [_tokenOriginChainId: BigNumberish, _nonNativeToken: AddressLike],
     [string],
     "view"
   >;
 
-  calculateCreate2TokenAddress: TypedContractMethod<
-    [_originChainId: BigNumberish, _originToken: AddressLike],
+  ensureTokenIsRegistered: TypedContractMethod<
+    [_nativeToken: AddressLike],
     [string],
-    "view"
+    "nonpayable"
   >;
 
   getERC20Getters: TypedContractMethod<
@@ -286,13 +559,49 @@ export interface IL2NativeTokenVault extends BaseContract {
 
   originChainId: TypedContractMethod<[assetId: BytesLike], [bigint], "view">;
 
+  owner: TypedContractMethod<[], [string], "view">;
+
+  pause: TypedContractMethod<[], [void], "nonpayable">;
+
+  paused: TypedContractMethod<[], [boolean], "view">;
+
+  pendingOwner: TypedContractMethod<[], [string], "view">;
+
   registerToken: TypedContractMethod<
-    [_l1Token: AddressLike],
+    [_nativeToken: AddressLike],
+    [void],
+    "nonpayable"
+  >;
+
+  renounceOwnership: TypedContractMethod<[], [void], "nonpayable">;
+
+  setLegacyTokenAssetId: TypedContractMethod<
+    [_l2TokenAddress: AddressLike],
     [void],
     "nonpayable"
   >;
 
   tokenAddress: TypedContractMethod<[assetId: BytesLike], [string], "view">;
+
+  tokenDataOriginChainId: TypedContractMethod<
+    [_erc20Data: BytesLike],
+    [bigint],
+    "view"
+  >;
+
+  transferOwnership: TypedContractMethod<
+    [newOwner: AddressLike],
+    [void],
+    "nonpayable"
+  >;
+
+  tryRegisterTokenFromBurnData: TypedContractMethod<
+    [_burnData: BytesLike, _expectedAssetId: BytesLike],
+    [void],
+    "nonpayable"
+  >;
+
+  unpause: TypedContractMethod<[], [void], "nonpayable">;
 
   getFunction<T extends ContractMethod = ContractMethod>(
     key: string | FunctionFragment
@@ -302,25 +611,56 @@ export interface IL2NativeTokenVault extends BaseContract {
     nameOrSignature: "ASSET_ROUTER"
   ): TypedContractMethod<[], [string], "view">;
   getFunction(
+    nameOrSignature: "BASE_TOKEN_ASSET_ID"
+  ): TypedContractMethod<[], [string], "view">;
+  getFunction(
+    nameOrSignature: "L1_CHAIN_ID"
+  ): TypedContractMethod<[], [bigint], "view">;
+  getFunction(
+    nameOrSignature: "L2_LEGACY_SHARED_BRIDGE"
+  ): TypedContractMethod<[], [string], "view">;
+  getFunction(
     nameOrSignature: "WETH_TOKEN"
   ): TypedContractMethod<[], [string], "view">;
   getFunction(
-    nameOrSignature: "assetId"
-  ): TypedContractMethod<[token: AddressLike], [string], "view">;
+    nameOrSignature: "acceptOwnership"
+  ): TypedContractMethod<[], [void], "nonpayable">;
   getFunction(
-    nameOrSignature: "calculateAssetId"
+    nameOrSignature: "assetId"
+  ): TypedContractMethod<[tokenAddress: AddressLike], [string], "view">;
+  getFunction(
+    nameOrSignature: "bridgeBurn"
   ): TypedContractMethod<
-    [_chainId: BigNumberish, _tokenAddress: AddressLike],
+    [
+      _chainId: BigNumberish,
+      _l2MsgValue: BigNumberish,
+      _assetId: BytesLike,
+      _originalCaller: AddressLike,
+      _data: BytesLike
+    ],
     [string],
-    "view"
+    "payable"
   >;
+  getFunction(
+    nameOrSignature: "bridgeMint"
+  ): TypedContractMethod<
+    [_chainId: BigNumberish, _assetId: BytesLike, _data: BytesLike],
+    [void],
+    "payable"
+  >;
+  getFunction(
+    nameOrSignature: "bridgedTokenBeacon"
+  ): TypedContractMethod<[], [string], "view">;
   getFunction(
     nameOrSignature: "calculateCreate2TokenAddress"
   ): TypedContractMethod<
-    [_originChainId: BigNumberish, _originToken: AddressLike],
+    [_tokenOriginChainId: BigNumberish, _nonNativeToken: AddressLike],
     [string],
     "view"
   >;
+  getFunction(
+    nameOrSignature: "ensureTokenIsRegistered"
+  ): TypedContractMethod<[_nativeToken: AddressLike], [string], "nonpayable">;
   getFunction(
     nameOrSignature: "getERC20Getters"
   ): TypedContractMethod<
@@ -335,12 +675,60 @@ export interface IL2NativeTokenVault extends BaseContract {
     nameOrSignature: "originChainId"
   ): TypedContractMethod<[assetId: BytesLike], [bigint], "view">;
   getFunction(
+    nameOrSignature: "owner"
+  ): TypedContractMethod<[], [string], "view">;
+  getFunction(
+    nameOrSignature: "pause"
+  ): TypedContractMethod<[], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "paused"
+  ): TypedContractMethod<[], [boolean], "view">;
+  getFunction(
+    nameOrSignature: "pendingOwner"
+  ): TypedContractMethod<[], [string], "view">;
+  getFunction(
     nameOrSignature: "registerToken"
-  ): TypedContractMethod<[_l1Token: AddressLike], [void], "nonpayable">;
+  ): TypedContractMethod<[_nativeToken: AddressLike], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "renounceOwnership"
+  ): TypedContractMethod<[], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "setLegacyTokenAssetId"
+  ): TypedContractMethod<[_l2TokenAddress: AddressLike], [void], "nonpayable">;
   getFunction(
     nameOrSignature: "tokenAddress"
   ): TypedContractMethod<[assetId: BytesLike], [string], "view">;
+  getFunction(
+    nameOrSignature: "tokenDataOriginChainId"
+  ): TypedContractMethod<[_erc20Data: BytesLike], [bigint], "view">;
+  getFunction(
+    nameOrSignature: "transferOwnership"
+  ): TypedContractMethod<[newOwner: AddressLike], [void], "nonpayable">;
+  getFunction(
+    nameOrSignature: "tryRegisterTokenFromBurnData"
+  ): TypedContractMethod<
+    [_burnData: BytesLike, _expectedAssetId: BytesLike],
+    [void],
+    "nonpayable"
+  >;
+  getFunction(
+    nameOrSignature: "unpause"
+  ): TypedContractMethod<[], [void], "nonpayable">;
 
+  getEvent(
+    key: "BridgeBurn"
+  ): TypedContractEvent<
+    BridgeBurnEvent.InputTuple,
+    BridgeBurnEvent.OutputTuple,
+    BridgeBurnEvent.OutputObject
+  >;
+  getEvent(
+    key: "BridgeMint"
+  ): TypedContractEvent<
+    BridgeMintEvent.InputTuple,
+    BridgeMintEvent.OutputTuple,
+    BridgeMintEvent.OutputObject
+  >;
   getEvent(
     key: "BridgedTokenBeaconUpdated"
   ): TypedContractEvent<
@@ -356,11 +744,46 @@ export interface IL2NativeTokenVault extends BaseContract {
     FinalizeDepositEvent.OutputObject
   >;
   getEvent(
+    key: "Initialized"
+  ): TypedContractEvent<
+    InitializedEvent.InputTuple,
+    InitializedEvent.OutputTuple,
+    InitializedEvent.OutputObject
+  >;
+  getEvent(
     key: "L2TokenBeaconUpdated"
   ): TypedContractEvent<
     L2TokenBeaconUpdatedEvent.InputTuple,
     L2TokenBeaconUpdatedEvent.OutputTuple,
     L2TokenBeaconUpdatedEvent.OutputObject
+  >;
+  getEvent(
+    key: "OwnershipTransferStarted"
+  ): TypedContractEvent<
+    OwnershipTransferStartedEvent.InputTuple,
+    OwnershipTransferStartedEvent.OutputTuple,
+    OwnershipTransferStartedEvent.OutputObject
+  >;
+  getEvent(
+    key: "OwnershipTransferred"
+  ): TypedContractEvent<
+    OwnershipTransferredEvent.InputTuple,
+    OwnershipTransferredEvent.OutputTuple,
+    OwnershipTransferredEvent.OutputObject
+  >;
+  getEvent(
+    key: "Paused"
+  ): TypedContractEvent<
+    PausedEvent.InputTuple,
+    PausedEvent.OutputTuple,
+    PausedEvent.OutputObject
+  >;
+  getEvent(
+    key: "Unpaused"
+  ): TypedContractEvent<
+    UnpausedEvent.InputTuple,
+    UnpausedEvent.OutputTuple,
+    UnpausedEvent.OutputObject
   >;
   getEvent(
     key: "WithdrawalInitiated"
@@ -371,6 +794,28 @@ export interface IL2NativeTokenVault extends BaseContract {
   >;
 
   filters: {
+    "BridgeBurn(uint256,bytes32,address,address,uint256)": TypedContractEvent<
+      BridgeBurnEvent.InputTuple,
+      BridgeBurnEvent.OutputTuple,
+      BridgeBurnEvent.OutputObject
+    >;
+    BridgeBurn: TypedContractEvent<
+      BridgeBurnEvent.InputTuple,
+      BridgeBurnEvent.OutputTuple,
+      BridgeBurnEvent.OutputObject
+    >;
+
+    "BridgeMint(uint256,bytes32,address,uint256)": TypedContractEvent<
+      BridgeMintEvent.InputTuple,
+      BridgeMintEvent.OutputTuple,
+      BridgeMintEvent.OutputObject
+    >;
+    BridgeMint: TypedContractEvent<
+      BridgeMintEvent.InputTuple,
+      BridgeMintEvent.OutputTuple,
+      BridgeMintEvent.OutputObject
+    >;
+
     "BridgedTokenBeaconUpdated(address,bytes32)": TypedContractEvent<
       BridgedTokenBeaconUpdatedEvent.InputTuple,
       BridgedTokenBeaconUpdatedEvent.OutputTuple,
@@ -393,6 +838,17 @@ export interface IL2NativeTokenVault extends BaseContract {
       FinalizeDepositEvent.OutputObject
     >;
 
+    "Initialized(uint8)": TypedContractEvent<
+      InitializedEvent.InputTuple,
+      InitializedEvent.OutputTuple,
+      InitializedEvent.OutputObject
+    >;
+    Initialized: TypedContractEvent<
+      InitializedEvent.InputTuple,
+      InitializedEvent.OutputTuple,
+      InitializedEvent.OutputObject
+    >;
+
     "L2TokenBeaconUpdated(address,bytes32)": TypedContractEvent<
       L2TokenBeaconUpdatedEvent.InputTuple,
       L2TokenBeaconUpdatedEvent.OutputTuple,
@@ -402,6 +858,50 @@ export interface IL2NativeTokenVault extends BaseContract {
       L2TokenBeaconUpdatedEvent.InputTuple,
       L2TokenBeaconUpdatedEvent.OutputTuple,
       L2TokenBeaconUpdatedEvent.OutputObject
+    >;
+
+    "OwnershipTransferStarted(address,address)": TypedContractEvent<
+      OwnershipTransferStartedEvent.InputTuple,
+      OwnershipTransferStartedEvent.OutputTuple,
+      OwnershipTransferStartedEvent.OutputObject
+    >;
+    OwnershipTransferStarted: TypedContractEvent<
+      OwnershipTransferStartedEvent.InputTuple,
+      OwnershipTransferStartedEvent.OutputTuple,
+      OwnershipTransferStartedEvent.OutputObject
+    >;
+
+    "OwnershipTransferred(address,address)": TypedContractEvent<
+      OwnershipTransferredEvent.InputTuple,
+      OwnershipTransferredEvent.OutputTuple,
+      OwnershipTransferredEvent.OutputObject
+    >;
+    OwnershipTransferred: TypedContractEvent<
+      OwnershipTransferredEvent.InputTuple,
+      OwnershipTransferredEvent.OutputTuple,
+      OwnershipTransferredEvent.OutputObject
+    >;
+
+    "Paused(address)": TypedContractEvent<
+      PausedEvent.InputTuple,
+      PausedEvent.OutputTuple,
+      PausedEvent.OutputObject
+    >;
+    Paused: TypedContractEvent<
+      PausedEvent.InputTuple,
+      PausedEvent.OutputTuple,
+      PausedEvent.OutputObject
+    >;
+
+    "Unpaused(address)": TypedContractEvent<
+      UnpausedEvent.InputTuple,
+      UnpausedEvent.OutputTuple,
+      UnpausedEvent.OutputObject
+    >;
+    Unpaused: TypedContractEvent<
+      UnpausedEvent.InputTuple,
+      UnpausedEvent.OutputTuple,
+      UnpausedEvent.OutputObject
     >;
 
     "WithdrawalInitiated(address,address,address,uint256)": TypedContractEvent<

--- a/src/typechain/factories/IBridgehub__factory.ts
+++ b/src/typechain/factories/IBridgehub__factory.ts
@@ -11,6 +11,194 @@ const _abi = [
     inputs: [
       {
         indexed: true,
+        internalType: "bytes32",
+        name: "assetInfo",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "_assetAddress",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "additionalData",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+    ],
+    name: "AssetRegistered",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+    ],
+    name: "BaseTokenAssetIdRegistered",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "BridgeBurn",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "BridgeMint",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "chainTypeManager",
+        type: "address",
+      },
+    ],
+    name: "ChainTypeManagerAdded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "chainTypeManager",
+        type: "address",
+      },
+    ],
+    name: "ChainTypeManagerRemoved",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "zkChain",
+        type: "address",
+      },
+    ],
+    name: "MigrationFinalized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "settlementLayerChainId",
+        type: "uint256",
+      },
+    ],
+    name: "MigrationStarted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
         internalType: "address",
         name: "oldAdmin",
         type: "address",
@@ -37,7 +225,7 @@ const _abi = [
       {
         indexed: false,
         internalType: "address",
-        name: "stateTransitionManager",
+        name: "chainTypeManager",
         type: "address",
       },
       {
@@ -70,6 +258,38 @@ const _abi = [
     type: "event",
   },
   {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bool",
+        name: "isWhitelisted",
+        type: "bool",
+      },
+    ],
+    name: "SettlementLayerRegistered",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "L1_CHAIN_ID",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [],
     name: "acceptAdmin",
     outputs: [],
@@ -80,11 +300,11 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_stateTransitionManager",
+        name: "_chainTypeManager",
         type: "address",
       },
     ],
-    name: "addStateTransitionManager",
+    name: "addChainTypeManager",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -92,14 +312,59 @@ const _abi = [
   {
     inputs: [
       {
+        internalType: "bytes32",
+        name: "_baseTokenAssetId",
+        type: "bytes32",
+      },
+    ],
+    name: "addTokenAssetId",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "admin",
+    outputs: [
+      {
         internalType: "address",
-        name: "_token",
+        name: "",
         type: "address",
       },
     ],
-    name: "addToken",
-    outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_baseTokenAssetId",
+        type: "bytes32",
+      },
+    ],
+    name: "assetIdIsRegistered",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "assetRouter",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
   },
   {
@@ -128,15 +393,162 @@ const _abi = [
         name: "_chainId",
         type: "uint256",
       },
+    ],
+    name: "baseTokenAssetId",
+    outputs: [
       {
-        internalType: "address",
-        name: "_stateTransitionManager",
-        type: "address",
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "_msgValue",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "_assetId",
+        type: "bytes32",
       },
       {
         internalType: "address",
-        name: "_baseToken",
+        name: "_originalCaller",
         type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "_data",
+        type: "bytes",
+      },
+    ],
+    name: "bridgeBurn",
+    outputs: [
+      {
+        internalType: "bytes",
+        name: "_bridgeMintData",
+        type: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "_assetId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "_data",
+        type: "bytes",
+      },
+    ],
+    name: "bridgeMint",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "_assetId",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_depositSender",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "_data",
+        type: "bytes",
+      },
+    ],
+    name: "bridgeRecoverFailedTransfer",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+    ],
+    name: "chainTypeManager",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_chainTypeManager",
+        type: "address",
+      },
+    ],
+    name: "chainTypeManagerIsRegistered",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "_chainTypeManager",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "_baseTokenAssetId",
+        type: "bytes32",
       },
       {
         internalType: "uint256",
@@ -153,6 +565,11 @@ const _abi = [
         name: "_initData",
         type: "bytes",
       },
+      {
+        internalType: "bytes[]",
+        name: "_factoryDeps",
+        type: "bytes[]",
+      },
     ],
     name: "createNewChain",
     outputs: [
@@ -168,6 +585,112 @@ const _abi = [
   {
     inputs: [
       {
+        internalType: "address",
+        name: "_ctmAddress",
+        type: "address",
+      },
+    ],
+    name: "ctmAssetIdFromAddress",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+    ],
+    name: "ctmAssetIdFromChainId",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_assetInfo",
+        type: "bytes32",
+      },
+    ],
+    name: "ctmAssetIdToAddress",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "_canonicalTxHash",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint64",
+        name: "_expirationTimestamp",
+        type: "uint64",
+      },
+    ],
+    name: "forwardTransactionOnGateway",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getAllZKChainChainIDs",
+    outputs: [
+      {
+        internalType: "uint256[]",
+        name: "",
+        type: "uint256[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getAllZKChains",
+    outputs: [
+      {
+        internalType: "address[]",
+        name: "",
+        type: "address[]",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
         internalType: "uint256",
         name: "_chainId",
         type: "uint256",
@@ -177,6 +700,38 @@ const _abi = [
     outputs: [
       {
         internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+    ],
+    name: "getZKChain",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "l1CtmDeployer",
+    outputs: [
+      {
+        internalType: "contract ICTMDeploymentTracker",
         name: "",
         type: "address",
       },
@@ -216,6 +771,39 @@ const _abi = [
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "messageRoot",
+    outputs: [
+      {
+        internalType: "contract IMessageRoot",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "migrationPaused",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pauseMigration",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -397,12 +985,61 @@ const _abi = [
   {
     inputs: [
       {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
         internalType: "address",
-        name: "_stateTransitionManager",
+        name: "_hyperchain",
         type: "address",
       },
     ],
-    name: "removeStateTransitionManager",
+    name: "registerAlreadyDeployedZKChain",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+    ],
+    name: "registerLegacyChain",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_newSettlementLayerChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bool",
+        name: "_isWhitelisted",
+        type: "bool",
+      },
+    ],
+    name: "registerSettlementLayer",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_chainTypeManager",
+        type: "address",
+      },
+    ],
+    name: "removeChainTypeManager",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -543,6 +1180,47 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
+        name: "_sharedBridge",
+        type: "address",
+      },
+      {
+        internalType: "contract ICTMDeploymentTracker",
+        name: "_l1CtmDeployer",
+        type: "address",
+      },
+      {
+        internalType: "contract IMessageRoot",
+        name: "_messageRoot",
+        type: "address",
+      },
+    ],
+    name: "setAddresses",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_additionalData",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_assetAddress",
+        type: "address",
+      },
+    ],
+    name: "setCTMAssetAddress",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
         name: "_newPendingAdmin",
         type: "address",
       },
@@ -555,14 +1233,20 @@ const _abi = [
   {
     inputs: [
       {
-        internalType: "address",
-        name: "_sharedBridge",
-        type: "address",
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
       },
     ],
-    name: "setSharedBridge",
-    outputs: [],
-    stateMutability: "nonpayable",
+    name: "settlementLayer",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
   },
   {
@@ -570,12 +1254,19 @@ const _abi = [
     name: "sharedBridge",
     outputs: [
       {
-        internalType: "contract IL1SharedBridge",
+        internalType: "address",
         name: "",
         type: "address",
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "unpauseMigration",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -586,45 +1277,7 @@ const _abi = [
         type: "uint256",
       },
     ],
-    name: "stateTransitionManager",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "_stateTransitionManager",
-        type: "address",
-      },
-    ],
-    name: "stateTransitionManagerIsRegistered",
-    outputs: [
-      {
-        internalType: "bool",
-        name: "",
-        type: "bool",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "_baseToken",
-        type: "address",
-      },
-    ],
-    name: "tokenIsRegistered",
+    name: "whitelistedSettlementLayers",
     outputs: [
       {
         internalType: "bool",

--- a/src/typechain/factories/IL1AssetRouter__factory.ts
+++ b/src/typechain/factories/IL1AssetRouter__factory.ts
@@ -10,115 +10,29 @@ import type {
 
 const _abi = [
   {
+    anonymous: false,
     inputs: [
       {
-        internalType: "address",
-        name: "_l1WethAddress",
-        type: "address",
-      },
-      {
-        internalType: "address",
-        name: "_bridgehub",
-        type: "address",
-      },
-      {
-        internalType: "address",
-        name: "_l1Nullifier",
-        type: "address",
-      },
-      {
-        internalType: "uint256",
-        name: "_eraChainId",
-        type: "uint256",
-      },
-      {
-        internalType: "address",
-        name: "_eraDiamondProxy",
-        type: "address",
-      },
-    ],
-    stateMutability: "nonpayable",
-    type: "constructor",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "addr",
-        type: "address",
-      },
-    ],
-    name: "AddressAlreadyUsed",
-    type: "error",
-  },
-  {
-    inputs: [
-      {
+        indexed: true,
         internalType: "bytes32",
         name: "assetId",
         type: "bytes32",
       },
-    ],
-    name: "AssetHandlerDoesNotExist",
-    type: "error",
-  },
-  {
-    inputs: [
       {
+        indexed: true,
         internalType: "bytes32",
-        name: "assetId",
+        name: "additionalData",
         type: "bytes32",
       },
-    ],
-    name: "AssetIdNotSupported",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "NotInitializedReentrancyGuard",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "Reentrancy",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "SlotOccupied",
-    type: "error",
-  },
-  {
-    inputs: [
       {
+        indexed: false,
         internalType: "address",
-        name: "token",
+        name: "assetDeploymentTracker",
         type: "address",
       },
     ],
-    name: "TokenNotSupported",
-    type: "error",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "caller",
-        type: "address",
-      },
-    ],
-    name: "Unauthorized",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "UnsupportedEncodingVersion",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "ZeroAddress",
-    type: "error",
+    name: "AssetDeploymentTrackerRegistered",
+    type: "event",
   },
   {
     anonymous: false,
@@ -157,42 +71,11 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "_assetAddress",
+        name: "_assetHandlerAddress",
         type: "address",
       },
     ],
     name: "AssetHandlerRegistered",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "bytes32",
-        name: "assetId",
-        type: "bytes32",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "assetHandlerAddress",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "bytes32",
-        name: "additionalData",
-        type: "bytes32",
-      },
-      {
-        indexed: false,
-        internalType: "address",
-        name: "assetDeploymentTracker",
-        type: "address",
-      },
-    ],
-    name: "AssetHandlerRegisteredInitial",
     type: "event",
   },
   {
@@ -386,19 +269,6 @@ const _abi = [
     anonymous: false,
     inputs: [
       {
-        indexed: false,
-        internalType: "uint8",
-        name: "version",
-        type: "uint8",
-      },
-    ],
-    name: "Initialized",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
         indexed: true,
         internalType: "uint256",
         name: "chainId",
@@ -425,7 +295,7 @@ const _abi = [
       {
         indexed: false,
         internalType: "address",
-        name: "l1Asset",
+        name: "l1Token",
         type: "address",
       },
       {
@@ -439,70 +309,6 @@ const _abi = [
     type: "event",
   },
   {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "previousOwner",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnershipTransferStarted",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "previousOwner",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnershipTransferred",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-    ],
-    name: "Paused",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: false,
-        internalType: "address",
-        name: "account",
-        type: "address",
-      },
-    ],
-    name: "Unpaused",
-    type: "event",
-  },
-  {
     inputs: [],
     name: "BRIDGE_HUB",
     outputs: [
@@ -510,32 +316,6 @@ const _abi = [
         internalType: "contract IBridgehub",
         name: "",
         type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "ERA_CHAIN_ID",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "L1_CHAIN_ID",
-    outputs: [
-      {
-        internalType: "uint256",
-        name: "",
-        type: "uint256",
       },
     ],
     stateMutability: "view",
@@ -568,36 +348,10 @@ const _abi = [
     type: "function",
   },
   {
-    inputs: [],
-    name: "acceptOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
     inputs: [
       {
         internalType: "bytes32",
-        name: "assetId",
-        type: "bytes32",
-      },
-    ],
-    name: "assetDeploymentTracker",
-    outputs: [
-      {
-        internalType: "address",
-        name: "assetDeploymentTracker",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "bytes32",
-        name: "assetId",
+        name: "_assetId",
         type: "bytes32",
       },
     ],
@@ -605,7 +359,7 @@ const _abi = [
     outputs: [
       {
         internalType: "address",
-        name: "assetHandlerAddress",
+        name: "",
         type: "address",
       },
     ],
@@ -808,59 +562,6 @@ const _abi = [
   {
     inputs: [
       {
-        internalType: "uint256",
-        name: "_chainId",
-        type: "uint256",
-      },
-      {
-        internalType: "address",
-        name: "_depositSender",
-        type: "address",
-      },
-      {
-        internalType: "address",
-        name: "_l1Token",
-        type: "address",
-      },
-      {
-        internalType: "uint256",
-        name: "_amount",
-        type: "uint256",
-      },
-      {
-        internalType: "bytes32",
-        name: "_l2TxHash",
-        type: "bytes32",
-      },
-      {
-        internalType: "uint256",
-        name: "_l2BatchNumber",
-        type: "uint256",
-      },
-      {
-        internalType: "uint256",
-        name: "_l2MessageIndex",
-        type: "uint256",
-      },
-      {
-        internalType: "uint16",
-        name: "_l2TxNumberInBatch",
-        type: "uint16",
-      },
-      {
-        internalType: "bytes32[]",
-        name: "_merkleProof",
-        type: "bytes32[]",
-      },
-    ],
-    name: "claimFailedDeposit",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
         internalType: "address",
         name: "_originalCaller",
         type: "address",
@@ -927,7 +628,7 @@ const _abi = [
     ],
     name: "finalizeDeposit",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     type: "function",
   },
   {
@@ -1000,19 +701,6 @@ const _abi = [
   {
     inputs: [
       {
-        internalType: "address",
-        name: "_owner",
-        type: "address",
-      },
-    ],
-    name: "initialize",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
         internalType: "uint256",
         name: "_chainId",
         type: "uint256",
@@ -1040,11 +728,17 @@ const _abi = [
     type: "function",
   },
   {
-    inputs: [],
-    name: "legacyBridge",
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+    ],
+    name: "l2BridgeAddress",
     outputs: [
       {
-        internalType: "contract IL1ERC20Bridge",
+        internalType: "address",
         name: "",
         type: "address",
       },
@@ -1063,59 +757,6 @@ const _abi = [
       },
     ],
     stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "owner",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "pause",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "paused",
-    outputs: [
-      {
-        internalType: "bool",
-        name: "",
-        type: "bool",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "pendingOwner",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "renounceOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -1206,26 +847,6 @@ const _abi = [
         type: "bool",
       },
     ],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "transferOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "unpause",
-    outputs: [],
     stateMutability: "nonpayable",
     type: "function",
   },

--- a/src/typechain/factories/IL1NativeTokenVault__factory.ts
+++ b/src/typechain/factories/IL1NativeTokenVault__factory.ts
@@ -56,6 +56,19 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "L1_CHAIN_ID",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "L1_NULLIFIER",
     outputs: [
       {
@@ -107,19 +120,23 @@ const _abi = [
         type: "uint256",
       },
       {
+        internalType: "bytes32",
+        name: "_assetId",
+        type: "bytes32",
+      },
+      {
         internalType: "address",
-        name: "_tokenAddress",
+        name: "_originalCaller",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_assetHandlerAddressOnCounterpart",
         type: "address",
       },
     ],
-    name: "calculateAssetId",
-    outputs: [
-      {
-        internalType: "bytes32",
-        name: "",
-        type: "bytes32",
-      },
-    ],
+    name: "bridgeCheckCounterpartAddress",
+    outputs: [],
     stateMutability: "view",
     type: "function",
   },
@@ -169,6 +186,25 @@ const _abi = [
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_nativeToken",
+        type: "address",
+      },
+    ],
+    name: "ensureTokenIsRegistered",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -251,6 +287,24 @@ const _abi = [
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "_burnData",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes32",
+        name: "_expectedAssetId",
+        type: "bytes32",
+      },
+    ],
+    name: "tryRegisterTokenFromBurnData",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
 ] as const;

--- a/src/typechain/factories/IL1Nullifier__factory.ts
+++ b/src/typechain/factories/IL1Nullifier__factory.ts
@@ -7,1015 +7,486 @@ import type { IL1Nullifier, IL1NullifierInterface } from "../IL1Nullifier";
 
 const _abi = [
   {
-    type: "constructor",
+    anonymous: false,
     inputs: [
       {
-        name: "_bridgehub",
-        type: "address",
-        internalType: "contract IBridgehub",
-      },
-      {
-        name: "_interopCenter",
-        type: "address",
-        internalType: "contract IInteropCenter",
-      },
-      {
-        name: "_eraChainId",
-        type: "uint256",
+        indexed: true,
         internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
       },
       {
-        name: "_eraDiamondProxy",
-        type: "address",
-        internalType: "address",
+        indexed: true,
+        internalType: "bytes32",
+        name: "txDataHash",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "l2DepositTxHash",
+        type: "bytes32",
       },
     ],
-    stateMutability: "nonpayable",
+    name: "BridgehubDepositFinalized",
+    type: "event",
   },
   {
-    type: "function",
+    inputs: [],
     name: "BRIDGE_HUB",
-    inputs: [],
     outputs: [
       {
-        name: "",
-        type: "address",
         internalType: "contract IBridgehub",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "__DEPRECATED_admin",
-    inputs: [],
-    outputs: [
-      {
         name: "",
         type: "address",
-        internalType: "address",
       },
     ],
     stateMutability: "view",
+    type: "function",
   },
   {
-    type: "function",
-    name: "__DEPRECATED_chainBalance",
     inputs: [
       {
-        name: "chainId",
-        type: "uint256",
         internalType: "uint256",
-      },
-      {
-        name: "l1Token",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    outputs: [
-      {
-        name: "balance",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "__DEPRECATED_l2BridgeAddress",
-    inputs: [
-      {
-        name: "chainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-    outputs: [
-      {
-        name: "l2Bridge",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "__DEPRECATED_pendingAdmin",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "acceptOwnership",
-    inputs: [],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "bridgeRecoverFailedTransfer",
-    inputs: [
-      {
         name: "_chainId",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "address",
         name: "_depositSender",
         type: "address",
-        internalType: "address",
       },
       {
+        internalType: "bytes32",
         name: "_assetId",
         type: "bytes32",
-        internalType: "bytes32",
       },
       {
+        internalType: "bytes",
         name: "_assetData",
         type: "bytes",
-        internalType: "bytes",
       },
       {
+        internalType: "bytes32",
         name: "_l2TxHash",
         type: "bytes32",
-        internalType: "bytes32",
       },
       {
+        internalType: "uint256",
         name: "_l2BatchNumber",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint256",
         name: "_l2MessageIndex",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint16",
         name: "_l2TxNumberInBatch",
         type: "uint16",
-        internalType: "uint16",
       },
       {
+        internalType: "bytes32[]",
         name: "_merkleProof",
         type: "bytes32[]",
-        internalType: "bytes32[]",
       },
     ],
+    name: "bridgeRecoverFailedTransfer",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "bridgehubConfirmL2TransactionForwarded",
     inputs: [
       {
+        internalType: "uint256",
         name: "_chainId",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "bytes32",
         name: "_txDataHash",
         type: "bytes32",
-        internalType: "bytes32",
       },
       {
+        internalType: "bytes32",
         name: "_txHash",
         type: "bytes32",
-        internalType: "bytes32",
       },
     ],
+    name: "bridgehubConfirmL2TransactionForwarded",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "chainBalance",
     inputs: [
       {
+        internalType: "uint256",
         name: "_chainId",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "address",
         name: "_token",
         type: "address",
-        internalType: "address",
       },
     ],
+    name: "chainBalance",
     outputs: [
       {
+        internalType: "uint256",
         name: "",
         type: "uint256",
-        internalType: "uint256",
       },
     ],
     stateMutability: "view",
+    type: "function",
   },
   {
-    type: "function",
-    name: "claimFailedDeposit",
     inputs: [
       {
+        internalType: "uint256",
         name: "_chainId",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "address",
         name: "_depositSender",
         type: "address",
-        internalType: "address",
       },
       {
+        internalType: "address",
         name: "_l1Token",
         type: "address",
-        internalType: "address",
       },
       {
+        internalType: "uint256",
         name: "_amount",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "bytes32",
         name: "_l2TxHash",
         type: "bytes32",
-        internalType: "bytes32",
       },
       {
+        internalType: "uint256",
         name: "_l2BatchNumber",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint256",
         name: "_l2MessageIndex",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint16",
         name: "_l2TxNumberInBatch",
         type: "uint16",
-        internalType: "uint16",
       },
       {
+        internalType: "bytes32[]",
         name: "_merkleProof",
         type: "bytes32[]",
-        internalType: "bytes32[]",
       },
     ],
+    name: "claimFailedDeposit",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
+    inputs: [
+      {
+        internalType: "address",
+        name: "_depositSender",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_l1Token",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "_l2TxHash",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "_l2BatchNumber",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "_l2MessageIndex",
+        type: "uint256",
+      },
+      {
+        internalType: "uint16",
+        name: "_l2TxNumberInBatch",
+        type: "uint16",
+      },
+      {
+        internalType: "bytes32[]",
+        name: "_merkleProof",
+        type: "bytes32[]",
+      },
+    ],
     name: "claimFailedDepositLegacyErc20Bridge",
-    inputs: [
-      {
-        name: "_depositSender",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "_l1Token",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "_amount",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "_l2TxHash",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "_l2BatchNumber",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "_l2MessageIndex",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "_l2TxNumberInBatch",
-        type: "uint16",
-        internalType: "uint16",
-      },
-      {
-        name: "_merkleProof",
-        type: "bytes32[]",
-        internalType: "bytes32[]",
-      },
-    ],
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "depositHappened",
     inputs: [
       {
-        name: "chainId",
-        type: "uint256",
         internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
       },
       {
-        name: "l2DepositTxHash",
-        type: "bytes32",
         internalType: "bytes32",
+        name: "_l2TxHash",
+        type: "bytes32",
       },
     ],
+    name: "depositHappened",
     outputs: [
       {
-        name: "depositDataHash",
-        type: "bytes32",
         internalType: "bytes32",
+        name: "",
+        type: "bytes32",
       },
     ],
     stateMutability: "view",
+    type: "function",
   },
   {
-    type: "function",
-    name: "encodeTxDataHash",
     inputs: [
       {
-        name: "_encodingVersion",
-        type: "bytes1",
-        internalType: "bytes1",
-      },
-      {
-        name: "_originalCaller",
-        type: "address",
-        internalType: "address",
-      },
-      {
-        name: "_assetId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "_transferData",
-        type: "bytes",
-        internalType: "bytes",
-      },
-    ],
-    outputs: [
-      {
-        name: "txDataHash",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "finalizeDeposit",
-    inputs: [
-      {
-        name: "_finalizeWithdrawalParams",
-        type: "tuple",
-        internalType: "struct FinalizeL1DepositParams",
         components: [
           {
+            internalType: "uint256",
             name: "chainId",
             type: "uint256",
-            internalType: "uint256",
           },
           {
+            internalType: "uint256",
             name: "l2BatchNumber",
             type: "uint256",
-            internalType: "uint256",
           },
           {
+            internalType: "uint256",
             name: "l2MessageIndex",
             type: "uint256",
-            internalType: "uint256",
           },
           {
+            internalType: "address",
             name: "l2Sender",
             type: "address",
-            internalType: "address",
           },
           {
+            internalType: "uint16",
             name: "l2TxNumberInBatch",
             type: "uint16",
-            internalType: "uint16",
           },
           {
+            internalType: "bytes",
             name: "message",
             type: "bytes",
-            internalType: "bytes",
           },
           {
+            internalType: "bytes32[]",
             name: "merkleProof",
             type: "bytes32[]",
-            internalType: "bytes32[]",
           },
         ],
+        internalType: "struct FinalizeL1DepositParams",
+        name: "_finalizeWithdrawalParams",
+        type: "tuple",
       },
     ],
+    name: "finalizeDeposit",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "finalizeWithdrawal",
     inputs: [
       {
+        internalType: "uint256",
         name: "_chainId",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint256",
         name: "_l2BatchNumber",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint256",
         name: "_l2MessageIndex",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "uint16",
         name: "_l2TxNumberInBatch",
         type: "uint16",
-        internalType: "uint16",
       },
       {
+        internalType: "bytes",
         name: "_message",
         type: "bytes",
-        internalType: "bytes",
       },
       {
+        internalType: "bytes32[]",
         name: "_merkleProof",
         type: "bytes32[]",
-        internalType: "bytes32[]",
       },
     ],
+    name: "finalizeWithdrawal",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "initialize",
     inputs: [
       {
-        name: "_owner",
-        type: "address",
-        internalType: "address",
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
       },
       {
-        name: "_eraPostDiamondUpgradeFirstBatch",
-        type: "uint256",
         internalType: "uint256",
+        name: "_l2BatchNumber",
+        type: "uint256",
       },
       {
-        name: "_eraPostLegacyBridgeUpgradeFirstBatch",
-        type: "uint256",
         internalType: "uint256",
-      },
-      {
-        name: "_eraLegacyBridgeLastDepositBatch",
+        name: "_l2MessageIndex",
         type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "_eraLegacyBridgeLastDepositTxNumber",
-        type: "uint256",
-        internalType: "uint256",
       },
     ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
     name: "isWithdrawalFinalized",
-    inputs: [
-      {
-        name: "chainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "l2BatchNumber",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "l2ToL1MessageNumber",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
     outputs: [
       {
-        name: "isFinalized",
-        type: "bool",
         internalType: "bool",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "l1AssetRouter",
-    inputs: [],
-    outputs: [
-      {
         name: "",
-        type: "address",
-        internalType: "contract IL1AssetRouter",
+        type: "bool",
       },
     ],
     stateMutability: "view",
+    type: "function",
   },
   {
-    type: "function",
+    inputs: [],
     name: "l1NativeTokenVault",
-    inputs: [],
     outputs: [
       {
-        name: "",
-        type: "address",
         internalType: "contract IL1NativeTokenVault",
+        name: "",
+        type: "address",
       },
     ],
     stateMutability: "view",
+    type: "function",
   },
   {
-    type: "function",
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+    ],
     name: "l2BridgeAddress",
-    inputs: [
-      {
-        name: "_chainId",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
     outputs: [
       {
-        name: "",
-        type: "address",
         internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "legacyBridge",
-    inputs: [],
-    outputs: [
-      {
         name: "",
         type: "address",
-        internalType: "contract IL1ERC20Bridge",
       },
     ],
     stateMutability: "view",
+    type: "function",
   },
   {
+    inputs: [],
+    name: "legacyBridge",
+    outputs: [
+      {
+        internalType: "contract IL1ERC20Bridge",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
     type: "function",
-    name: "nullifyChainBalanceByNTV",
+  },
+  {
     inputs: [
       {
+        internalType: "uint256",
         name: "_chainId",
         type: "uint256",
-        internalType: "uint256",
       },
       {
+        internalType: "address",
         name: "_token",
         type: "address",
-        internalType: "address",
       },
     ],
+    name: "nullifyChainBalanceByNTV",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "owner",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "pause",
-    inputs: [],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "paused",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "pendingOwner",
-    inputs: [],
-    outputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-    stateMutability: "view",
-  },
-  {
-    type: "function",
-    name: "renounceOwnership",
-    inputs: [],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "setL1AssetRouter",
     inputs: [
       {
+        internalType: "address",
         name: "_l1AssetRouter",
         type: "address",
-        internalType: "address",
       },
     ],
+    name: "setL1AssetRouter",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "setL1Erc20Bridge",
     inputs: [
       {
-        name: "_legacyBridge",
-        type: "address",
-        internalType: "contract IL1ERC20Bridge",
-      },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "setL1NativeTokenVault",
-    inputs: [
-      {
-        name: "_l1NativeTokenVault",
-        type: "address",
         internalType: "contract IL1NativeTokenVault",
-      },
-    ],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "function",
-    name: "transferOwnership",
-    inputs: [
-      {
-        name: "newOwner",
+        name: "_nativeTokenVault",
         type: "address",
-        internalType: "address",
       },
     ],
+    name: "setL1NativeTokenVault",
     outputs: [],
     stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    type: "function",
-    name: "transferTokenToNTV",
     inputs: [
       {
+        internalType: "address",
         name: "_token",
         type: "address",
-        internalType: "address",
       },
     ],
+    name: "transferTokenToNTV",
     outputs: [],
     stateMutability: "nonpayable",
-  },
-  {
     type: "function",
-    name: "unpause",
-    inputs: [],
-    outputs: [],
-    stateMutability: "nonpayable",
-  },
-  {
-    type: "event",
-    name: "BridgehubDepositFinalized",
-    inputs: [
-      {
-        name: "chainId",
-        type: "uint256",
-        indexed: true,
-        internalType: "uint256",
-      },
-      {
-        name: "txDataHash",
-        type: "bytes32",
-        indexed: true,
-        internalType: "bytes32",
-      },
-      {
-        name: "l2DepositTxHash",
-        type: "bytes32",
-        indexed: true,
-        internalType: "bytes32",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "Initialized",
-    inputs: [
-      {
-        name: "version",
-        type: "uint8",
-        indexed: false,
-        internalType: "uint8",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "OwnershipTransferStarted",
-    inputs: [
-      {
-        name: "previousOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "newOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "OwnershipTransferred",
-    inputs: [
-      {
-        name: "previousOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-      {
-        name: "newOwner",
-        type: "address",
-        indexed: true,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "Paused",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        indexed: false,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "event",
-    name: "Unpaused",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-        indexed: false,
-        internalType: "address",
-      },
-    ],
-    anonymous: false,
-  },
-  {
-    type: "error",
-    name: "AddressAlreadySet",
-    inputs: [
-      {
-        name: "addr",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "DepositDoesNotExist",
-    inputs: [
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "DepositExists",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "EthTransferFailed",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "IncorrectTokenAddressFromNTV",
-    inputs: [
-      {
-        name: "assetId",
-        type: "bytes32",
-        internalType: "bytes32",
-      },
-      {
-        name: "tokenAddress",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "InvalidNTVBurnData",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidProof",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "InvalidSelector",
-    inputs: [
-      {
-        name: "func",
-        type: "bytes4",
-        internalType: "bytes4",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "L2WithdrawalMessageWrongLength",
-    inputs: [
-      {
-        name: "messageLen",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "LegacyBridgeNotSet",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "LegacyMethodForNonL1Token",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "NativeTokenVaultAlreadySet",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "NotInitializedReentrancyGuard",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "Reentrancy",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "SharedBridgeValueNotSet",
-    inputs: [
-      {
-        name: "",
-        type: "uint8",
-        internalType: "enum SharedBridgeKey",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "SlotOccupied",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "TokenNotLegacy",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "Unauthorized",
-    inputs: [
-      {
-        name: "caller",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "UnsupportedEncodingVersion",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "WithdrawalAlreadyFinalized",
-    inputs: [],
-  },
-  {
-    type: "error",
-    name: "WrongL2Sender",
-    inputs: [
-      {
-        name: "providedL2Sender",
-        type: "address",
-        internalType: "address",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "WrongMsgLength",
-    inputs: [
-      {
-        name: "expected",
-        type: "uint256",
-        internalType: "uint256",
-      },
-      {
-        name: "length",
-        type: "uint256",
-        internalType: "uint256",
-      },
-    ],
-  },
-  {
-    type: "error",
-    name: "ZeroAddress",
-    inputs: [],
   },
 ] as const;
 

--- a/src/typechain/factories/IL2AssetRouter__factory.ts
+++ b/src/typechain/factories/IL2AssetRouter__factory.ts
@@ -20,12 +20,18 @@ const _abi = [
       },
       {
         indexed: true,
+        internalType: "bytes32",
+        name: "additionalData",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
         internalType: "address",
-        name: "_assetAddress",
+        name: "assetDeploymentTracker",
         type: "address",
       },
     ],
-    name: "AssetHandlerRegistered",
+    name: "AssetDeploymentTrackerRegistered",
     type: "event",
   },
   {
@@ -40,23 +46,11 @@ const _abi = [
       {
         indexed: true,
         internalType: "address",
-        name: "assetHandlerAddress",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "bytes32",
-        name: "additionalData",
-        type: "bytes32",
-      },
-      {
-        indexed: false,
-        internalType: "address",
-        name: "assetDeploymentTracker",
+        name: "_assetHandlerAddress",
         type: "address",
       },
     ],
-    name: "AssetHandlerRegisteredInitial",
+    name: "AssetHandlerRegistered",
     type: "event",
   },
   {
@@ -228,6 +222,19 @@ const _abi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "L1_ASSET_ROUTER",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "bytes32",
@@ -266,20 +273,40 @@ const _abi = [
     ],
     name: "finalizeDeposit",
     outputs: [],
-    stateMutability: "nonpayable",
+    stateMutability: "payable",
     type: "function",
   },
   {
-    inputs: [],
-    name: "l1AssetRouter",
-    outputs: [
+    inputs: [
       {
         internalType: "address",
-        name: "",
+        name: "_l1Sender",
         type: "address",
       },
+      {
+        internalType: "address",
+        name: "_l2Receiver",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_l1Token",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_amount",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes",
+        name: "_data",
+        type: "bytes",
+      },
     ],
-    stateMutability: "view",
+    name: "finalizeDepositLegacyBridge",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -296,7 +323,7 @@ const _abi = [
       },
       {
         internalType: "address",
-        name: "_assetAddress",
+        name: "_assetHandlerAddress",
         type: "address",
       },
     ],
@@ -330,6 +357,19 @@ const _abi = [
         name: "_assetId",
         type: "bytes32",
       },
+    ],
+    name: "setLegacyTokenAssetHandler",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_assetId",
+        type: "bytes32",
+      },
       {
         internalType: "bytes",
         name: "_transferData",
@@ -337,7 +377,13 @@ const _abi = [
       },
     ],
     name: "withdraw",
-    outputs: [],
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
     stateMutability: "nonpayable",
     type: "function",
   },

--- a/src/typechain/factories/IL2NativeTokenVault__factory.ts
+++ b/src/typechain/factories/IL2NativeTokenVault__factory.ts
@@ -10,6 +10,291 @@ import type {
 
 const _abi = [
   {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_l1ChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "_aliasedOwner",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "_l2TokenProxyBytecodeHash",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_legacySharedBridge",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_bridgedTokenBeacon",
+        type: "address",
+      },
+      {
+        internalType: "bool",
+        name: "_contractsDeployedAlready",
+        type: "bool",
+      },
+      {
+        internalType: "address",
+        name: "_wethToken",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "_baseTokenAssetId",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "expected",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "supplied",
+        type: "address",
+      },
+    ],
+    name: "AddressMismatch",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AmountMustBeGreaterThanZero",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "AssetIdAlreadyRegistered",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "expected",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "supplied",
+        type: "bytes32",
+      },
+    ],
+    name: "AssetIdMismatch",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+    ],
+    name: "AssetIdNotSupported",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "BurningNativeWETHNotSupported",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "DeployFailed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "DeployingBridgedTokenForNativeToken",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "EmptyAddress",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "EmptyBytes32",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "EmptyDeposit",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "EmptyToken",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidNTVBurnData",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NoLegacySharedBridge",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NonEmptyMsgValue",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "TokenIsLegacy",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "TokenNotLegacy",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "token",
+        type: "address",
+      },
+    ],
+    name: "TokenNotSupported",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "TokensWithFeesNotSupported",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "U32CastOverflow",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "caller",
+        type: "address",
+      },
+    ],
+    name: "Unauthorized",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "UnsupportedEncodingVersion",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "expected",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "actual",
+        type: "uint256",
+      },
+    ],
+    name: "ValueMismatch",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ZeroAddress",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "BridgeBurn",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "assetId",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "BridgeMint",
+    type: "event",
+  },
+  {
     anonymous: false,
     inputs: [
       {
@@ -63,6 +348,19 @@ const _abi = [
     anonymous: false,
     inputs: [
       {
+        indexed: false,
+        internalType: "uint8",
+        name: "version",
+        type: "uint8",
+      },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
         indexed: true,
         internalType: "address",
         name: "l2TokenBeacon",
@@ -76,6 +374,70 @@ const _abi = [
       },
     ],
     name: "L2TokenBeaconUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferStarted",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "previousOwner",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "OwnershipTransferred",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "Paused",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "Unpaused",
     type: "event",
   },
   {
@@ -124,6 +486,45 @@ const _abi = [
   },
   {
     inputs: [],
+    name: "BASE_TOKEN_ASSET_ID",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "L1_CHAIN_ID",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "L2_LEGACY_SHARED_BRIDGE",
+    outputs: [
+      {
+        internalType: "contract IL2SharedBridgeLegacy",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
     name: "WETH_TOKEN",
     outputs: [
       {
@@ -136,10 +537,17 @@ const _abi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "acceptOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "address",
-        name: "token",
+        name: "tokenAddress",
         type: "address",
       },
     ],
@@ -147,7 +555,7 @@ const _abi = [
     outputs: [
       {
         internalType: "bytes32",
-        name: "",
+        name: "assetId",
         type: "bytes32",
       },
     ],
@@ -162,17 +570,68 @@ const _abi = [
         type: "uint256",
       },
       {
-        internalType: "address",
-        name: "_tokenAddress",
-        type: "address",
+        internalType: "uint256",
+        name: "_l2MsgValue",
+        type: "uint256",
       },
-    ],
-    name: "calculateAssetId",
-    outputs: [
       {
         internalType: "bytes32",
-        name: "",
+        name: "_assetId",
         type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_originalCaller",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "_data",
+        type: "bytes",
+      },
+    ],
+    name: "bridgeBurn",
+    outputs: [
+      {
+        internalType: "bytes",
+        name: "_bridgeMintData",
+        type: "bytes",
+      },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "_assetId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "_data",
+        type: "bytes",
+      },
+    ],
+    name: "bridgeMint",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "bridgedTokenBeacon",
+    outputs: [
+      {
+        internalType: "contract IBeacon",
+        name: "",
+        type: "address",
       },
     ],
     stateMutability: "view",
@@ -182,12 +641,12 @@ const _abi = [
     inputs: [
       {
         internalType: "uint256",
-        name: "_originChainId",
+        name: "_tokenOriginChainId",
         type: "uint256",
       },
       {
         internalType: "address",
-        name: "_originToken",
+        name: "_nonNativeToken",
         type: "address",
       },
     ],
@@ -200,6 +659,25 @@ const _abi = [
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_nativeToken",
+        type: "address",
+      },
+    ],
+    name: "ensureTokenIsRegistered",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "tokenAssetId",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "nonpayable",
     type: "function",
   },
   {
@@ -238,7 +716,7 @@ const _abi = [
     outputs: [
       {
         internalType: "address",
-        name: "",
+        name: "expectedToken",
         type: "address",
       },
     ],
@@ -257,8 +735,54 @@ const _abi = [
     outputs: [
       {
         internalType: "uint256",
-        name: "",
+        name: "originChainId",
         type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "owner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pause",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "paused",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pendingOwner",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
       },
     ],
     stateMutability: "view",
@@ -268,11 +792,31 @@ const _abi = [
     inputs: [
       {
         internalType: "address",
-        name: "_l1Token",
+        name: "_nativeToken",
         type: "address",
       },
     ],
     name: "registerToken",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_l2TokenAddress",
+        type: "address",
+      },
+    ],
+    name: "setLegacyTokenAssetId",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",
@@ -289,11 +833,68 @@ const _abi = [
     outputs: [
       {
         internalType: "address",
-        name: "",
+        name: "tokenAddress",
         type: "address",
       },
     ],
     stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "_erc20Data",
+        type: "bytes",
+      },
+    ],
+    name: "tokenDataOriginChainId",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "tokenOriginChainId",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newOwner",
+        type: "address",
+      },
+    ],
+    name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "_burnData",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes32",
+        name: "_expectedAssetId",
+        type: "bytes32",
+      },
+    ],
+    name: "tryRegisterTokenFromBurnData",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "unpause",
+    outputs: [],
+    stateMutability: "nonpayable",
     type: "function",
   },
 ] as const;

--- a/tests/integration/provider.test.ts
+++ b/tests/integration/provider.test.ts
@@ -19,12 +19,10 @@ describe('Provider', () => {
   const wallet = new Wallet(PRIVATE_KEY1, provider);
   const ethProvider = ethers.getDefaultProvider(L1_CHAIN_URL);
   let receipt: types.TransactionReceipt;
-  let baseToken: string;
 
   before('setup', async function () {
     this.timeout(25_000);
 
-    baseToken = await provider.getBaseTokenContractAddress();
     const tx = await wallet.transfer({
       token: utils.LEGACY_ETH_ADDRESS,
       to: ADDRESS2,
@@ -139,14 +137,6 @@ describe('Provider', () => {
     it('should return confirmed tokens', async () => {
       const result = await provider.getConfirmedTokens();
       expect(result).to.have.lengthOf(1);
-    });
-  });
-
-  describe('#getAllAccountBalances()', () => {
-    it('should return the all balances of the account at `address`', async () => {
-      const result = await provider.getAllAccountBalances(ADDRESS1);
-      const expected = IS_ETH_BASED ? 2 : 3;
-      expect(Object.keys(result)).to.have.lengthOf(expected);
     });
   });
 
@@ -290,11 +280,6 @@ describe('Provider', () => {
   });
 
   describe('#l2TokenAddress()', () => {
-    it('should return the L2 base address', async () => {
-      const result = await provider.l2TokenAddress(baseToken);
-      expect(result).to.be.equal(utils.L2_BASE_TOKEN_ADDRESS);
-    });
-
     it('should return the L2 ETH address', async () => {
       if (!IS_ETH_BASED) {
         const result = await provider.l2TokenAddress(utils.LEGACY_ETH_ADDRESS);
@@ -973,17 +958,6 @@ describe('Provider', () => {
         const result = await provider.estimateDefaultBridgeDepositL2Gas(
           ethProvider,
           utils.LEGACY_ETH_ADDRESS,
-          ethers.parseEther('1'),
-          ADDRESS2,
-          ADDRESS1
-        );
-        expect(result > 0n).to.be.true;
-      });
-
-      it('should return estimation for base token', async () => {
-        const result = await provider.estimateDefaultBridgeDepositL2Gas(
-          ethProvider,
-          await provider.getBaseTokenContractAddress(),
           ethers.parseEther('1'),
           ADDRESS2,
           ADDRESS1

--- a/tests/integration/signer.test.ts
+++ b/tests/integration/signer.test.ts
@@ -55,14 +55,6 @@ describe('VoidSigner', () => {
     });
   });
 
-  describe('#getAllBalances()', () => {
-    it('should return all balances', async () => {
-      const result = await signer.getAllBalances();
-      const expected = IS_ETH_BASED ? 2 : 3;
-      expect(Object.keys(result)).to.have.lengthOf(expected);
-    });
-  });
-
   describe('#getL2BridgeContracts()', () => {
     it('should return a L2 bridge contracts', async () => {
       const result = await signer.getL2BridgeContracts();
@@ -364,14 +356,6 @@ describe('L2VoidSigner', () => {
     it('should return the `L2VoidSigner` balance', async () => {
       const result = await signer.getBalance();
       expect(result > 0n).to.be.true;
-    });
-  });
-
-  describe('#getAllBalances()', () => {
-    it('should return all balances', async () => {
-      const result = await signer.getAllBalances();
-      const expected = IS_ETH_BASED ? 2 : 3;
-      expect(Object.keys(result)).to.have.lengthOf(expected);
     });
   });
 

--- a/tests/integration/smart-account.test.ts
+++ b/tests/integration/smart-account.test.ts
@@ -119,14 +119,6 @@ describe('SmartAccount', async () => {
     });
   });
 
-  describe('#getAllBalances()', () => {
-    it('should return all balances', async () => {
-      const result = await account.getAllBalances();
-      const expected = IS_ETH_BASED ? 2 : 3;
-      expect(Object.keys(result)).to.have.lengthOf(expected);
-    });
-  });
-
   describe('#getDeploymentNonce()', () => {
     it('should return the deployment nonce', async () => {
       const result = await account.getDeploymentNonce();

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -178,14 +178,6 @@ describe('Wallet', () => {
     });
   });
 
-  describe('#getAllBalances()', () => {
-    it('should return the all balances', async () => {
-      const result = await wallet.getAllBalances();
-      const expected = IS_ETH_BASED ? 2 : 3;
-      expect(Object.keys(result)).to.have.lengthOf(expected);
-    });
-  });
-
   describe('#getL2BridgeContracts()', () => {
     it('should return a L2 bridge contracts', async () => {
       const result = await wallet.getL2BridgeContracts();


### PR DESCRIPTION
To address the changes mentioned in #253, the SDK will need a more significant redesign to properly handle the challenges encountered when relying on on-chain data instead of RPC methods.

The core issue is that the Provider was originally designed only to interact with L2 nodes via RPC calls to retrieve necessary L1 data. As a result, it cannot communicate with the Bridgehub (deployed on L1) to fetch bridge and token addresses. This limitation breaks nearly all Provider methods related to bridging. The following methods are no longer supported:

- `l2TokenAddress`, 
- `l1TokenAddress`, 
- `getWithdrawTx`, 
- `estimateDefaultBridgeDepositL2Gas`, 
- `estimateCustomBridgeDepositL2Gas`, 
- `getMainContractAddress`, 
- `getBaseTokenContractAddress`, 
- `getL2TransactionFromPriorityOp`, 
- `getPriorityOpResponse`, 
- `getPriorityOpConfirmation`, 
- `getBalance`, 
- `getWithdrawTx`, 
- `estimateGasWithdraw`.

Currently, there are two possible solutions to address this problem:

### Solution 1 (Implemented in this draft PR)
Deprecate the affected methods listed above (and remove them in a future release), and reimplement them in the `Wallet` class. This approach preserves the clear design, and the `Provider` remains focused solely on interacting with the L2 node, without dependencies on L1.

### Solution 2
Introduce a breaking change to the `Provider` constructor by requiring an L1 provider, enabling it to continue supporting bridge-related methods.