### PR TITLE
feat: add new fields to BatchDetails interface for zks_getL1BatchDetails API

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -789,11 +789,34 @@ export interface BatchDetails {
   l1GasPrice: number;
   /** Fair gas price on L2 at the time of the block's execution. */
   l2FairGasPrice: number;
+  /** Fair pubdata price on L2 at the time of the block's execution. */
+  fairPubdataPrice: number;
   /** Hashes of the base system contracts involved in the batch. */
   baseSystemContractsHashes: {
     bootloader: string;
     default_aa: string;
+    evm_emulator?: string;
   };
+  /** Chain ID where the commit transaction was submitted. */
+  commitChainId?: number;
+  /** Finality status of the commit transaction. */
+  commitTxFinality?: string;
+  /** Chain ID where the precommit transaction was submitted. */
+  precommitChainId?: number;
+  /** Finality status of the precommit transaction. */
+  precommitTxFinality?: string;
+  /** Transaction hash of the precommit operation on L1. */
+  precommitTxHash?: string;
+  /** Timestamp when the block was precommitted on L1. */
+  precommittedAt?: Date;
+  /** Chain ID where the prove transaction was submitted. */
+  proveChainId?: number;
+  /** Finality status of the prove transaction. */
+  proveTxFinality?: string;
+  /** Chain ID where the execute transaction was submitted. */
+  executeChainId?: number;
+  /** Finality status of the execute transaction. */
+  executeTxFinality?: string;
 }
 
 /** Contains block information. */


### PR DESCRIPTION
# What :computer: 
- Add fairPubdataPrice field for L2 public data pricing
- Add evm_emulator hash to baseSystemContractsHashes
- Add commitChainId and commitTxFinality for commit transaction details
- Add precommitChainId, precommitTxFinality, precommitTxHash, and precommittedAt for precommit operations
- Add proveChainId and proveTxFinality for prove transaction details
- Add executeChainId and executeTxFinality for execute transaction details

# Why :hand:
- Consistency with fields returned from `zks_getL1BatchDetails`

