### PR TITLE
feat: add getVerificationArgs method

### DIFF
--- a/src/interop-utils.ts
+++ b/src/interop-utils.ts
@@ -148,7 +148,11 @@ export function classifyPhase(d: TxDetailsLite): BatchPhase {
   if (d.status === 'failed') return 'FAILED';
   if (d.status === 'rejected') return 'REJECTED';
 
-  if (d.status === 'included') {
+  if (
+    d.status === 'included' ||
+    d.status === 'fastFinalized' ||
+    d.status === 'verified'
+  ) {
     if (d.ethExecuteTxHash) return 'EXECUTED';
     if (d.ethProveTxHash) return 'PROVING';
     if (d.ethCommitTxHash) return 'SENDING';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1172,3 +1172,21 @@ export type TxDetailsLite = {
   ethProveTxHash: string | null;
   ethExecuteTxHash: string | null;
 };
+
+/**
+ * Input arguments for proveL2MessageInclusionShared method on L2MessageVerification contract
+ *
+ * @public
+ * @category Interop v29
+ */
+export type ProveL2MessageInclusionSharedArgs = {
+  srcChainId: number;
+  l1BatchNumber: number;
+  l1BatchTxIndex: number;
+  msgData: {
+    txNumberInBatch: number;
+    sender: `0x${string}`;
+    data: `0x${string}`;
+  };
+  gatewayProof: string[];
+};


### PR DESCRIPTION
Adds a new method to just the the input args for the proveL2MessageInclusionShared method on the target's L2MessageVerification contract. This helps with the use case of verifying a message in a contract.