### PR TITLE
fix: use ntv assetId

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -850,11 +850,6 @@ export function JsonRpcApiProvider<
       // For L1 native tokens we can use the legacy withdraw method.
       if (!isTokenL1Native) {
         const bridge = await this.connectL2AssetRouter();
-        const chainId = Number((await this.getNetwork()).chainId);
-        const assetId = encodeNativeTokenVaultAssetId(
-          BigInt(chainId),
-          tx.token
-        );
         const assetData = encodeNativeTokenVaultTransferData(
           BigInt(tx.amount),
           tx.to!,


### PR DESCRIPTION
# What :computer: 
Currently it is not possible to withdraw some L2-B native token from some other L2-A using the SDK, as the asset ID is[ incorrectly derived](https://github.com/zksync-sdk/zksync-ethers/blob/main/src/provider.ts#L854) using the L2-A chain ID and token address, instead of the original values. This PR fixes it by using the NTV's asset ID.

