### PR TITLE
fix: remove legacy bridge usage

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -831,7 +831,17 @@ export function JsonRpcApiProvider<
       }
 
       let populatedTx;
-      if (tx.bridgeAddress) {
+      const ntv = await this.connectL2NativeTokenVault();
+      const assetId = await ntv.assetId(tx.token);
+      const originChainId = await ntv.originChainId(assetId);
+      const l1ChainId = await this.getL1ChainId();
+      const isTokenL1Native =
+        originChainId === BigInt(l1ChainId) ||
+        tx.token === ETH_ADDRESS_IN_CONTRACTS;
+
+      // to match previous behavior of `getWithdrawTx` for backward compatibility,
+      // custom bridge is used only when bridgeAddress is provided and the token is native on L1
+      if (tx.bridgeAddress && isTokenL1Native) {
         const bridge = await this.connectL2Bridge(tx.bridgeAddress);
         populatedTx = await bridge.withdraw.populateTransaction(
           tx.to!,
@@ -840,8 +850,6 @@ export function JsonRpcApiProvider<
           tx.overrides
         );
       } else {
-        const ntv = await this.connectL2NativeTokenVault();
-        const assetId = await ntv.assetId(tx.token);
         const bridge = await this.connectL2AssetRouter();
         const assetData = encodeNativeTokenVaultTransferData(
           BigInt(tx.amount),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -763,7 +763,8 @@ export function JsonRpcApiProvider<
      * @param transaction.token The token address.
      * @param [transaction.from] The sender's address.
      * @param [transaction.to] The recipient's address.
-     * @param [transaction.bridgeAddress] The bridge address.
+     * @param [transaction.bridgeAddress] The address of a custom bridge. If provided, the withdrawal
+     * is routed through that bridge instead of the asset router. Use this for bridges not yet migrated to NTV.
      * @param [transaction.paymasterParams] Paymaster parameters.
      * @param [transaction.overrides] Transaction overrides including `gasLimit`, `gasPrice`, and `value`.
      */
@@ -830,43 +831,26 @@ export function JsonRpcApiProvider<
       }
 
       let populatedTx;
-      // we get the tokens data, assetId and originChainId
-      const ntv = await this.connectL2NativeTokenVault();
-      const assetId = await ntv.assetId(tx.token);
-      const originChainId = await ntv.originChainId(assetId);
-      const l1ChainId = await this.getL1ChainId();
-
-      const isTokenL1Native =
-        originChainId === BigInt(l1ChainId) ||
-        tx.token === ETH_ADDRESS_IN_CONTRACTS;
-      if (!tx.bridgeAddress) {
-        const bridgeAddresses = await this.getDefaultBridgeAddresses();
-        // If the legacy L2SharedBridge is deployed we use it for l1 native tokens.
-        tx.bridgeAddress = isTokenL1Native
-          ? bridgeAddresses.sharedL2
-          : L2_ASSET_ROUTER_ADDRESS;
-      }
-      // For non L1 native tokens we need to use the AssetRouter.
-      // For L1 native tokens we can use the legacy withdraw method.
-      if (!isTokenL1Native) {
+      if (tx.bridgeAddress) {
+        const bridge = await this.connectL2Bridge(tx.bridgeAddress);
+        populatedTx = await bridge.withdraw.populateTransaction(
+          tx.to!,
+          tx.token,
+          tx.amount,
+          tx.overrides
+        );
+      } else {
+        const ntv = await this.connectL2NativeTokenVault();
+        const assetId = await ntv.assetId(tx.token);
         const bridge = await this.connectL2AssetRouter();
         const assetData = encodeNativeTokenVaultTransferData(
           BigInt(tx.amount),
           tx.to!,
           tx.token
         );
-
         populatedTx = await bridge.withdraw.populateTransaction(
           assetId,
           assetData,
-          tx.overrides
-        );
-      } else {
-        const bridge = await this.connectL2Bridge(tx.bridgeAddress!);
-        populatedTx = await bridge.withdraw.populateTransaction(
-          tx.to!,
-          tx.token,
-          tx.amount,
           tx.overrides
         );
       }

--- a/tests/integration/account-abstraction.test.ts
+++ b/tests/integration/account-abstraction.test.ts
@@ -107,7 +107,7 @@ describe('Account Abstraction', () => {
       walletTokenBalanceAfterTx ===
         walletTokenBalanceBeforeTx - minimalAllowance + mintAmount
     ).to.be.true;
-  }).timeout(30_000);
+  }).timeout(40_000);
 
   it('use multisig account', async () => {
     const storageValue = 500n;
@@ -176,7 +176,7 @@ describe('Account Abstraction', () => {
     expect(multisigAccountBalanceBeforeTx > multisigAccountBalanceAfterTx).to.be
       .true;
     expect(await storage.get()).to.be.equal(storageValue);
-  }).timeout(25_000);
+  }).timeout(40_000);
 
   it('use a contract with smart account as a runner to send transactions that utilize a paymaster', async () => {
     const minimalAllowance = 1n;
@@ -220,5 +220,5 @@ describe('Account Abstraction', () => {
         accountApprovalTokenBalanceBeforeTx - minimalAllowance
     ).to.be.true;
     expect(await storage.get()).to.be.equal(storageValue);
-  }).timeout(25_000);
+  }).timeout(40_000);
 });

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1766,6 +1766,482 @@ describe('Wallet', () => {
     }).timeout(120_000);
   });
 
+  describe('#withdraw() with bridgeAddress', () => {
+    if (IS_ETH_BASED) {
+      it('should withdraw ETH to the L1 network', async () => {
+        const amount = 7_000_000_000n;
+        const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+        const l2BalanceBeforeWithdrawal = await wallet.getBalance();
+        const withdrawTx = await wallet.withdraw({
+          token: utils.LEGACY_ETH_ADDRESS,
+          to: await wallet.getAddress(),
+          amount: amount,
+          bridgeAddress: bridgeAddresses.sharedL2,
+        });
+        await withdrawTx.waitFinalize();
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+        const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+          withdrawTx.hash
+        );
+        const result = await finalizeWithdrawTx.wait();
+        const l2BalanceAfterWithdrawal = await wallet.getBalance();
+        expect(result).not.to.be.null;
+        expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal >= amount)
+          .to.be.true;
+      }).timeout(120_000);
+
+      it('should withdraw ETH to the L1 network using paymaster to cover fee', async () => {
+        const amount = 7_000_000_000n;
+        const minimalAllowance = 1n;
+        const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+
+        const paymasterBalanceBeforeWithdrawal =
+          await provider.getBalance(PAYMASTER);
+        const paymasterTokenBalanceBeforeWithdrawal = await provider.getBalance(
+          PAYMASTER,
+          'latest',
+          APPROVAL_TOKEN
+        );
+        const l2BalanceBeforeWithdrawal = await wallet.getBalance();
+        const l2ApprovalTokenBalanceBeforeWithdrawal =
+          await wallet.getBalance(APPROVAL_TOKEN);
+
+        const withdrawTx = await wallet.withdraw({
+          token: utils.ETH_ADDRESS_IN_CONTRACTS,
+          to: await wallet.getAddress(),
+          amount: amount,
+          bridgeAddress: bridgeAddresses.sharedL2,
+          paymasterParams: utils.getPaymasterParams(PAYMASTER, {
+            type: 'ApprovalBased',
+            token: APPROVAL_TOKEN,
+            minimalAllowance: minimalAllowance,
+            innerInput: new Uint8Array(),
+          }),
+        });
+        await withdrawTx.waitFinalize();
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+        const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+          withdrawTx.hash
+        );
+        const result = await finalizeWithdrawTx.wait();
+
+        const paymasterBalanceAfterWithdrawal =
+          await provider.getBalance(PAYMASTER);
+        const paymasterTokenBalanceAfterWithdrawal = await provider.getBalance(
+          PAYMASTER,
+          'latest',
+          APPROVAL_TOKEN
+        );
+        const l2BalanceAfterWithdrawal = await wallet.getBalance();
+        const l2ApprovalTokenBalanceAfterWithdrawal =
+          await wallet.getBalance(APPROVAL_TOKEN);
+
+        expect(
+          paymasterBalanceBeforeWithdrawal - paymasterBalanceAfterWithdrawal >=
+            0n
+        ).to.be.true;
+        expect(
+          paymasterTokenBalanceAfterWithdrawal -
+            paymasterTokenBalanceBeforeWithdrawal
+        ).to.be.equal(minimalAllowance);
+
+        expect(
+          l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal
+        ).to.be.equal(amount);
+        expect(
+          l2ApprovalTokenBalanceAfterWithdrawal ===
+            l2ApprovalTokenBalanceBeforeWithdrawal - minimalAllowance
+        ).to.be.true;
+
+        expect(result).not.to.be.null;
+      }).timeout(120_000);
+    } else {
+      it('should withdraw ETH to the L1 network', async () => {
+        const amount = 7_000_000_000n;
+        const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+        const token = await wallet.l2TokenAddress(
+          utils.ETH_ADDRESS_IN_CONTRACTS
+        );
+        const l2BalanceBeforeWithdrawal = await wallet.getBalance(token);
+        const withdrawTx = await wallet.withdraw({
+          token: token,
+          to: await wallet.getAddress(),
+          amount: amount,
+          bridgeAddress: bridgeAddresses.sharedL2,
+        });
+        await withdrawTx.waitFinalize();
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+        const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+          withdrawTx.hash
+        );
+        const result = await finalizeWithdrawTx.wait();
+        const l2BalanceAfterWithdrawal = await wallet.getBalance(token);
+        expect(result).not.to.be.null;
+        expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal >= amount)
+          .to.be.true;
+      }).timeout(120_000);
+
+      it('should withdraw ETH to the L1 network using paymaster to cover fee', async () => {
+        const amount = 7_000_000_000n;
+        const minimalAllowance = 1n;
+        const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+
+        const token = await wallet.l2TokenAddress(
+          utils.ETH_ADDRESS_IN_CONTRACTS
+        );
+        const paymasterBalanceBeforeWithdrawal =
+          await provider.getBalance(PAYMASTER);
+        const paymasterTokenBalanceBeforeWithdrawal = await provider.getBalance(
+          PAYMASTER,
+          'latest',
+          APPROVAL_TOKEN
+        );
+        const l2BalanceBeforeWithdrawal = await wallet.getBalance(token);
+        const l2ApprovalTokenBalanceBeforeWithdrawal =
+          await wallet.getBalance(APPROVAL_TOKEN);
+
+        const withdrawTx = await wallet.withdraw({
+          token: token,
+          to: await wallet.getAddress(),
+          amount: amount,
+          bridgeAddress: bridgeAddresses.sharedL2,
+          paymasterParams: utils.getPaymasterParams(PAYMASTER, {
+            type: 'ApprovalBased',
+            token: APPROVAL_TOKEN,
+            minimalAllowance: minimalAllowance,
+            innerInput: new Uint8Array(),
+          }),
+        });
+        await withdrawTx.waitFinalize();
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+        const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+          withdrawTx.hash
+        );
+        const result = await finalizeWithdrawTx.wait();
+
+        const paymasterBalanceAfterWithdrawal =
+          await provider.getBalance(PAYMASTER);
+        const paymasterTokenBalanceAfterWithdrawal = await provider.getBalance(
+          PAYMASTER,
+          'latest',
+          APPROVAL_TOKEN
+        );
+        const l2BalanceAfterWithdrawal = await wallet.getBalance(token);
+        const l2ApprovalTokenBalanceAfterWithdrawal =
+          await wallet.getBalance(APPROVAL_TOKEN);
+
+        expect(
+          paymasterBalanceBeforeWithdrawal - paymasterBalanceAfterWithdrawal >=
+            0n
+        ).to.be.true;
+        expect(
+          paymasterTokenBalanceAfterWithdrawal -
+            paymasterTokenBalanceBeforeWithdrawal
+        ).to.be.equal(minimalAllowance);
+
+        expect(
+          l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal
+        ).to.be.equal(amount);
+        expect(
+          l2ApprovalTokenBalanceAfterWithdrawal ===
+            l2ApprovalTokenBalanceBeforeWithdrawal - minimalAllowance
+        ).to.be.true;
+
+        expect(result).not.to.be.null;
+      }).timeout(120_000);
+
+      it('should withdraw base token to the L1 network', async () => {
+        const amount = 7_000_000_000n;
+        const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+        const l2BalanceBeforeWithdrawal = await wallet.getBalance();
+        const withdrawTx = await wallet.withdraw({
+          token: utils.L2_BASE_TOKEN_ADDRESS,
+          to: await wallet.getAddress(),
+          amount: amount,
+          bridgeAddress: bridgeAddresses.sharedL2,
+        });
+        await withdrawTx.waitFinalize();
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+        const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+          withdrawTx.hash
+        );
+        const result = await finalizeWithdrawTx.wait();
+        const l2BalanceAfterWithdrawal = await wallet.getBalance();
+        expect(result).not.to.be.null;
+        expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal >= amount)
+          .to.be.true;
+      }).timeout(120_000);
+
+      it('should withdraw base token to the L1 network using paymaster to cover fee', async () => {
+        const amount = 7_000_000_000n;
+        const minimalAllowance = 1n;
+        const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+
+        const paymasterBalanceBeforeWithdrawal =
+          await provider.getBalance(PAYMASTER);
+        const paymasterTokenBalanceBeforeWithdrawal = await provider.getBalance(
+          PAYMASTER,
+          'latest',
+          APPROVAL_TOKEN
+        );
+        const l2BalanceBeforeWithdrawal = await wallet.getBalance();
+        const l2ApprovalTokenBalanceBeforeWithdrawal =
+          await wallet.getBalance(APPROVAL_TOKEN);
+
+        const withdrawTx = await wallet.withdraw({
+          token: utils.L2_BASE_TOKEN_ADDRESS,
+          to: await wallet.getAddress(),
+          amount: amount,
+          bridgeAddress: bridgeAddresses.sharedL2,
+          paymasterParams: utils.getPaymasterParams(PAYMASTER, {
+            type: 'ApprovalBased',
+            token: APPROVAL_TOKEN,
+            minimalAllowance: minimalAllowance,
+            innerInput: new Uint8Array(),
+          }),
+        });
+        await withdrawTx.waitFinalize();
+        expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+        const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+          withdrawTx.hash
+        );
+        const result = await finalizeWithdrawTx.wait();
+
+        const paymasterBalanceAfterWithdrawal =
+          await provider.getBalance(PAYMASTER);
+        const paymasterTokenBalanceAfterWithdrawal = await provider.getBalance(
+          PAYMASTER,
+          'latest',
+          APPROVAL_TOKEN
+        );
+        const l2BalanceAfterWithdrawal = await wallet.getBalance();
+        const l2ApprovalTokenBalanceAfterWithdrawal =
+          await wallet.getBalance(APPROVAL_TOKEN);
+
+        expect(
+          paymasterBalanceBeforeWithdrawal - paymasterBalanceAfterWithdrawal >=
+            0n
+        ).to.be.true;
+        expect(
+          paymasterTokenBalanceAfterWithdrawal -
+            paymasterTokenBalanceBeforeWithdrawal
+        ).to.be.equal(minimalAllowance);
+
+        expect(
+          l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal
+        ).to.be.equal(amount);
+        expect(
+          l2ApprovalTokenBalanceAfterWithdrawal ===
+            l2ApprovalTokenBalanceBeforeWithdrawal - minimalAllowance
+        ).to.be.true;
+
+        expect(result).not.to.be.null;
+      }).timeout(120_000);
+    }
+
+    it('should withdraw DAI to the L1 network', async () => {
+      const amount = 5n;
+      const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+      const l2DAI = await provider.l2TokenAddress(DAI_L1);
+      const l2BalanceBeforeWithdrawal = await wallet.getBalance(l2DAI);
+      const l1BalanceBeforeWithdrawal = await wallet.getBalanceL1(DAI_L1);
+
+      const withdrawTx = await wallet.withdraw({
+        token: l2DAI,
+        to: await wallet.getAddress(),
+        amount: amount,
+        bridgeAddress: bridgeAddresses.sharedL2,
+      });
+      await withdrawTx.waitFinalize();
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+      const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+        withdrawTx.hash
+      );
+      const result = await finalizeWithdrawTx.wait();
+      const l2BalanceAfterWithdrawal = await wallet.getBalance(l2DAI);
+      const l1BalanceAfterWithdrawal = await wallet.getBalanceL1(DAI_L1);
+
+      expect(result).not.to.be.null;
+      expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal).to.be.equal(
+        amount
+      );
+      expect(l1BalanceAfterWithdrawal - l1BalanceBeforeWithdrawal).to.be.equal(
+        amount
+      );
+    }).timeout(120_000);
+
+    it('should withdraw DAI to the L1 network using paymaster to cover fee', async () => {
+      const amount = 5n;
+      const minimalAllowance = 1n;
+      const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+      const l2DAI = await provider.l2TokenAddress(DAI_L1);
+
+      const paymasterBalanceBeforeWithdrawal =
+        await provider.getBalance(PAYMASTER);
+      const paymasterTokenBalanceBeforeWithdrawal = await provider.getBalance(
+        PAYMASTER,
+        'latest',
+        APPROVAL_TOKEN
+      );
+      const l2BalanceBeforeWithdrawal = await wallet.getBalance(l2DAI);
+      const l1BalanceBeforeWithdrawal = await wallet.getBalanceL1(DAI_L1);
+      const l2ApprovalTokenBalanceBeforeWithdrawal =
+        await wallet.getBalance(APPROVAL_TOKEN);
+
+      const withdrawTx = await wallet.withdraw({
+        token: l2DAI,
+        to: await wallet.getAddress(),
+        amount: amount,
+        bridgeAddress: bridgeAddresses.sharedL2,
+        paymasterParams: utils.getPaymasterParams(PAYMASTER, {
+          type: 'ApprovalBased',
+          token: APPROVAL_TOKEN,
+          minimalAllowance: minimalAllowance,
+          innerInput: new Uint8Array(),
+        }),
+      });
+      await withdrawTx.waitFinalize();
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+      const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+        withdrawTx.hash
+      );
+      const result = await finalizeWithdrawTx.wait();
+
+      const paymasterBalanceAfterWithdrawal =
+        await provider.getBalance(PAYMASTER);
+      const paymasterTokenBalanceAfterWithdrawal = await provider.getBalance(
+        PAYMASTER,
+        'latest',
+        APPROVAL_TOKEN
+      );
+      const l2BalanceAfterWithdrawal = await wallet.getBalance(l2DAI);
+      const l1BalanceAfterWithdrawal = await wallet.getBalanceL1(DAI_L1);
+      const l2ApprovalTokenBalanceAfterWithdrawal =
+        await wallet.getBalance(APPROVAL_TOKEN);
+
+      expect(
+        paymasterBalanceBeforeWithdrawal - paymasterBalanceAfterWithdrawal >= 0n
+      ).to.be.true;
+      expect(
+        paymasterTokenBalanceAfterWithdrawal -
+          paymasterTokenBalanceBeforeWithdrawal
+      ).to.be.equal(minimalAllowance);
+      expect(
+        l2ApprovalTokenBalanceAfterWithdrawal ===
+          l2ApprovalTokenBalanceBeforeWithdrawal - minimalAllowance
+      ).to.be.true;
+
+      expect(result).not.to.be.null;
+      expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal).to.be.equal(
+        amount
+      );
+      expect(l1BalanceAfterWithdrawal - l1BalanceBeforeWithdrawal).to.be.equal(
+        amount
+      );
+    }).timeout(120_000);
+
+    it('should withdraw Crown to the L1 network', async () => {
+      const amount = 5n;
+      const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+      const l2Crown = APPROVAL_TOKEN;
+      const l2BalanceBeforeWithdrawal = await wallet.getBalance(l2Crown);
+
+      const withdrawTx = await wallet.withdraw({
+        token: l2Crown,
+        to: await wallet.getAddress(),
+        amount: amount,
+        bridgeAddress: bridgeAddresses.sharedL2,
+      });
+      await withdrawTx.waitFinalize();
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+      const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+        withdrawTx.hash
+      );
+      const result = await finalizeWithdrawTx.wait();
+      const l2BalanceAfterWithdrawal = await wallet.getBalance(l2Crown);
+
+      expect(result).not.to.be.null;
+      expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal).to.be.equal(
+        amount
+      );
+    }).timeout(120_000);
+
+    it('should withdraw Crown to the L1 network using paymaster to cover fee', async () => {
+      const amount = 5n;
+      const minimalAllowance = 1n;
+      const bridgeAddresses = await provider.getDefaultBridgeAddresses();
+      const l2Crown = APPROVAL_TOKEN;
+
+      const paymasterBalanceBeforeWithdrawal =
+        await provider.getBalance(PAYMASTER);
+      const paymasterTokenBalanceBeforeWithdrawal = await provider.getBalance(
+        PAYMASTER,
+        'latest',
+        APPROVAL_TOKEN
+      );
+      const l2BalanceBeforeWithdrawal = await wallet.getBalance(l2Crown);
+      const l2ApprovalTokenBalanceBeforeWithdrawal =
+        await wallet.getBalance(APPROVAL_TOKEN);
+
+      const withdrawTx = await wallet.withdraw({
+        token: l2Crown,
+        to: await wallet.getAddress(),
+        amount: amount,
+        bridgeAddress: bridgeAddresses.sharedL2,
+        paymasterParams: utils.getPaymasterParams(PAYMASTER, {
+          type: 'ApprovalBased',
+          token: APPROVAL_TOKEN,
+          minimalAllowance: minimalAllowance,
+          innerInput: new Uint8Array(),
+        }),
+      });
+      await withdrawTx.waitFinalize();
+      expect(await wallet.isWithdrawalFinalized(withdrawTx.hash)).to.be.false;
+
+      const finalizeWithdrawTx = await wallet.finalizeWithdrawal(
+        withdrawTx.hash
+      );
+      const result = await finalizeWithdrawTx.wait();
+
+      const paymasterBalanceAfterWithdrawal =
+        await provider.getBalance(PAYMASTER);
+      const paymasterTokenBalanceAfterWithdrawal = await provider.getBalance(
+        PAYMASTER,
+        'latest',
+        APPROVAL_TOKEN
+      );
+      const l2BalanceAfterWithdrawal = await wallet.getBalance(l2Crown);
+      const l2ApprovalTokenBalanceAfterWithdrawal =
+        await wallet.getBalance(APPROVAL_TOKEN);
+
+      expect(
+        paymasterBalanceBeforeWithdrawal - paymasterBalanceAfterWithdrawal >= 0n
+      ).to.be.true;
+      expect(
+        paymasterTokenBalanceAfterWithdrawal -
+          paymasterTokenBalanceBeforeWithdrawal
+      ).to.be.equal(minimalAllowance);
+      expect(
+        l2ApprovalTokenBalanceAfterWithdrawal ===
+          l2ApprovalTokenBalanceBeforeWithdrawal - minimalAllowance - amount
+      ).to.be.true;
+
+      expect(result).not.to.be.null;
+      expect(
+        l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal - minimalAllowance
+      ).to.be.equal(amount);
+    }).timeout(120_000);
+  });
+
   describe('#getRequestExecuteTx()', () => {
     const amount = 7_000_000_000;
     if (IS_ETH_BASED) {

--- a/tests/integration/wallet.test.ts
+++ b/tests/integration/wallet.test.ts
@@ -1042,7 +1042,7 @@ describe('Wallet', () => {
             'Cannot claim successful deposit!'
           );
         }
-      }).timeout(90_000);
+      }).timeout(120_000);
     } else {
       it('should throw an error when trying to claim successful deposit', async () => {
         const response = await wallet.deposit({
@@ -1060,7 +1060,7 @@ describe('Wallet', () => {
             'Cannot claim successful deposit!'
           );
         }
-      }).timeout(90_000);
+      }).timeout(120_000);
     }
   });
 
@@ -1285,7 +1285,7 @@ describe('Wallet', () => {
         expect(result).not.to.be.null;
         expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal >= amount)
           .to.be.true;
-      }).timeout(90_000);
+      }).timeout(120_000);
 
       it('should withdraw ETH to the L1 network using paymaster to cover fee', async () => {
         const amount = 7_000_000_000n;
@@ -1350,7 +1350,7 @@ describe('Wallet', () => {
         ).to.be.true;
 
         expect(result).not.to.be.null;
-      }).timeout(90_000);
+      }).timeout(120_000);
     } else {
       it('should withdraw ETH to the L1 network', async () => {
         const amount = 7_000_000_000n;
@@ -1374,7 +1374,7 @@ describe('Wallet', () => {
         expect(result).not.to.be.null;
         expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal >= amount)
           .to.be.true;
-      }).timeout(90_000);
+      }).timeout(120_000);
 
       it('should withdraw ETH to the L1 network using paymaster to cover fee', async () => {
         const amount = 7_000_000_000n;
@@ -1442,7 +1442,7 @@ describe('Wallet', () => {
         ).to.be.true;
 
         expect(result).not.to.be.null;
-      }).timeout(90_000);
+      }).timeout(120_000);
 
       it('should withdraw base token to the L1 network', async () => {
         const amount = 7_000_000_000n;
@@ -1463,7 +1463,7 @@ describe('Wallet', () => {
         expect(result).not.to.be.null;
         expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal >= amount)
           .to.be.true;
-      }).timeout(90_000);
+      }).timeout(120_000);
 
       it('should withdraw base token to the L1 network using paymaster to cover fee', async () => {
         const amount = 7_000_000_000n;
@@ -1528,7 +1528,7 @@ describe('Wallet', () => {
         ).to.be.true;
 
         expect(result).not.to.be.null;
-      }).timeout(90_000);
+      }).timeout(120_000);
     }
 
     it('should withdraw DAI to the L1 network', async () => {
@@ -1559,7 +1559,7 @@ describe('Wallet', () => {
       expect(l1BalanceAfterWithdrawal - l1BalanceBeforeWithdrawal).to.be.equal(
         amount
       );
-    }).timeout(90_000);
+    }).timeout(120_000);
 
     it('should withdraw DAI to the L1 network using paymaster to cover fee', async () => {
       const amount = 5n;
@@ -1628,7 +1628,7 @@ describe('Wallet', () => {
       expect(l1BalanceAfterWithdrawal - l1BalanceBeforeWithdrawal).to.be.equal(
         amount
       );
-    }).timeout(90_000);
+    }).timeout(120_000);
 
     it('should withdraw Crown to the L1 network', async () => {
       const amount = 5n;
@@ -1653,7 +1653,7 @@ describe('Wallet', () => {
       expect(l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal).to.be.equal(
         amount
       );
-    }).timeout(90_000);
+    }).timeout(120_000);
 
     it('should deposit Crown to the L2 network', async () => {
       const amount = 5n;
@@ -1699,7 +1699,7 @@ describe('Wallet', () => {
       expect(l1BalanceBeforeWithdrawal - l1BalanceAfterWithdrawal).to.be.equal(
         amount
       );
-    }).timeout(90_000);
+    }).timeout(120_000);
 
     it('should withdraw Crown to the L1 network using paymaster to cover fee', async () => {
       const amount = 5n;
@@ -1763,7 +1763,7 @@ describe('Wallet', () => {
       expect(
         l2BalanceBeforeWithdrawal - l2BalanceAfterWithdrawal - minimalAllowance
       ).to.be.equal(amount);
-    }).timeout(90_000);
+    }).timeout(120_000);
   });
 
   describe('#getRequestExecuteTx()', () => {


### PR DESCRIPTION
# What :computer: 
1. Get rid of the legacy bridge usage in the withdrawal functionality.
2. In general, tests complete within the configured timeouts. However, there are glitches where they take more time and eventually time out. I increased the timeouts to reduce flakiness.

# Why :hand:
Because legacy bridge was deprecated a while ago.